### PR TITLE
June 2 update

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -222,8 +222,8 @@ logic_glitches = {
                     with the intent for the glitchless version. Itemless
                     escape is only in logic with All Uses Enabled on.
                     '''},
-    'Superslides': {
-        'name'    : 'glitch_hess',
+    'All Superslides': {
+        'name'    : 'glitch_slide',
         'tags'    : ("General",),
         'tooltip' : '''\
                     Includes superslides, ESS, WESS, and HESS. While,
@@ -396,7 +396,7 @@ logic_glitches = {
         'name'    : 'glitch_upper_zora',
         'tags'    : ("Zora's River",),
         'tooltip' : '''\
-                    By going out of bounds with a ledge clip, you can unload
+                    By going out of bounds with a ladder clip, you can unload
                     the water and waterfall in the upper part of Zora's river
                     to access the LW shortcut and Zora's Domain with nothing.
                     '''},
@@ -479,6 +479,8 @@ logic_glitches = {
         'name'    : 'glitch_bk_skip_forest',
         'tags'    : ("General",),
         'tooltip' : '''\
+                    UPDATE: add child vine clip
+                    
                     You can jump into the railing at the top of the
                     stairway before the first Stalfos fight, perform
                     a ledge clip, and then jump straight to the loading
@@ -488,14 +490,18 @@ logic_glitches = {
                     '''},
     'Fire Temple BK skip': {
         'name'    : 'glitch_bk_skip_fire',
-        'tags'    : ("General",),
+        'tags'    : ("Fire Temple",),
         'tooltip' : '''\
-                    UPDATE: Add description here
+                    You can hammerslide or HESS from the hammer room to
+                    fall into the loading zone for the boss room from above.
+                    
+                    With All Uses Enabled on, this can also consider hovering
+                    from the room before the boss door.
                     
                     Applies to both vanilla and MQ.
                     '''},
     'Water Temple BK skip': {
-        'name'    : 'glitch_bk_skip_water',
+        'name'    : 'glitch_bk_skip_water_vanilla',
         'tags'    : ("General",),
         'tooltip' : '''\
                     UPDATE: Add description here.
@@ -537,7 +543,8 @@ logic_glitches = {
                     you can carry a second bomb flower to the
                     right-side bomb flower to superslide off of that
                     flower up the elevator pillar to light the eyes
-                    of the dead dodongo. Requires hoverboots.
+                    of the dead dodongo. Requires hoverboots, and
+                    requires superslides to be in logic.
                     '''},
     'Bombchu Groundjumps with Grabbable Objects': {
         'name'    : 'glitch_chu_groundjumps',
@@ -545,8 +552,8 @@ logic_glitches = {
         'tooltip' : '''\
                     You can store a groundjump using a bombchu to
                     destroy an object you can grab while canceling
-                    picking it up with a shield. Functions just
-                    like storing a ground jump off of a bomb, but
+                    picking it up with a shield. Functions similar
+                    to storing a ground jump off of a bomb, but
                     instead of the object exploding on its own, the
                     chu blows the object up.
                     '''},
@@ -560,6 +567,18 @@ logic_glitches = {
                     the next room while remaining in the current room,
                     allowing you to bypass some actors, such as the
                     water in BotW.
+                    '''},
+    'Bosses Without Usual Items': {
+        'name'    : 'glitch_hard_bosses',
+        'tags'    : ("General", "Dungeons",),
+        'tooltip' : '''\
+                    Puts various bosses into logic without items you would
+                    normally have. Included bosses are: King Dodongo with chus,
+                    Barinade with pots, Volvagia without tunic, Morpha without
+                    hookshot, and Bongo Bongo without projectiles.
+                    
+                    If All Uses Enabled is on and bomb hovers are in logic, then
+                    this also puts Phantom Ganon without projectiles in logic.
                     '''},
 }
 

--- a/data/Glitched World/Dodongos Cavern.json
+++ b/data/Glitched World/Dodongos Cavern.json
@@ -61,7 +61,7 @@
         },
         "exits": {
             "Dodongos Cavern Boss Area": "has_explosives or
-                here(can_use(Hover_Boots) and glitch_hess and Progressive_Strength_Upgrade and glitch_dodongo_strength)",
+                here(can_use(Hover_Boots) and glitch_slide and Progressive_Strength_Upgrade and glitch_dodongo_strength)",
             "Dodongos Cavern Lobby": "True"
         }
     },
@@ -71,11 +71,9 @@
         "locations": {
             "Dodongos Cavern Boss Room Chest": "True",
             "Dodongos Cavern King Dodongo Heart": "((can_jumpslash and has_explosives) or can_use(Megaton_Hammer)) and
-                (Bombs or Progressive_Strength_Upgrade or
-                (has_bombchus and (is_adult or can_hover)))",
+                (Bombs or Progressive_Strength_Upgrade or (glitch_hard_bosses and has_bombchus and (is_adult or can_hover)))",
             "King Dodongo": "((can_jumpslash and has_explosives) or can_use(Megaton_Hammer)) and
-            (Bombs or Progressive_Strength_Upgrade or
-            (has_bombchus and (is_adult or can_hover)))",
+                (Bombs or Progressive_Strength_Upgrade or (glitch_hard_bosses and has_bombchus and (is_adult or can_hover)))",
             "Dodongos Cavern GS Back Room": "here(can_blast_or_smash) or Blue_Fire"
         },
         "exits": {

--- a/data/Glitched World/Fire Temple.json
+++ b/data/Glitched World/Fire Temple.json
@@ -8,7 +8,7 @@
                 (can_use(Megaton_Hammer) or can_use(Hookshot) or (has_explosives and is_adult)) and (is_adult or can_groundjump)",
             "Fire Temple Boss Key Chest": "(((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Megaton_Hammer)) or
                 (can_weirdshot and Hookshot) or
-                (glitch_actor and can_use(Dins_Fire) and Bombs and can_live_dmg(1.5))",
+                (glitch_actor and can_use(Dins_Fire) and has_explosives and can_live_dmg(1.5))",
             "Fire Temple GS Boss Key Loop": "((Small_Key_Fire_Temple, 8) or not keysanity) and (is_adult or can_use(Megaton_Hammer))",
             "Fairy Pot": "has_bottle and (can_use(Hover_Boots) or can_use(Hookshot) or can_mega or can_hover)"
         },

--- a/data/Glitched World/Fire Temple.json
+++ b/data/Glitched World/Fire Temple.json
@@ -4,21 +4,29 @@
         "dungeon": "Fire Temple",
         "locations": {
             "Fire Temple Near Boss Chest" : "True",
-            "Fire Temple Flare Dancer Chest": "
-                ((Small_Key_Fire_Temple, 8) or not keysanity) and (can_use(Megaton_Hammer) or can_use(Hookshot) or has_explosives)",
-            "Fire Temple Boss Key Chest": "(
-                ((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Megaton_Hammer)) or (can_mega and can_use(Hookshot))",
-            "Fire Temple Volvagia Heart": "
-                (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer) and 
-                (Boss_Key_Fire_Temple or at('Fire Temple Flame Maze', True))",
-            "Volvagia": "
-                (can_use(Goron_Tunic) or (Fairy and has_explosives)) and can_use(Megaton_Hammer) and 
-                (Boss_Key_Fire_Temple or at('Fire Temple Flame Maze', True))",
-            "Fire Temple GS Boss Key Loop": "
-                ((Small_Key_Fire_Temple, 8) or not keysanity)"
+            "Fire Temple Flare Dancer Chest": "((Small_Key_Fire_Temple, 8) or not keysanity) and
+                (can_use(Megaton_Hammer) or can_use(Hookshot) or (has_explosives and is_adult)) and (is_adult or can_groundjump)",
+            "Fire Temple Boss Key Chest": "(((Small_Key_Fire_Temple, 8) or not keysanity) and can_use(Megaton_Hammer)) or
+                (can_weirdshot and Hookshot) or
+                (glitch_actor and can_use(Dins_Fire) and Bombs and can_live_dmg(1.5))",
+            "Fire Temple GS Boss Key Loop": "((Small_Key_Fire_Temple, 8) or not keysanity) and (is_adult or can_use(Megaton_Hammer))",
+            "Fairy Pot": "has_bottle and (can_use(Hover_Boots) or can_use(Hookshot) or can_mega or can_hover)"
         },
         "exits": {
-            "Fire Temple Big Lava Room":"(Small_Key_Fire_Temple, 2)"
+            "Fire Temple Big Lava Room":"(Small_Key_Fire_Temple, 2)",
+            # Once boss shuffle is implemented, child can damage boost from the pillar after adult knocks it down.
+            "Fire Temple Boss Room": "(is_adult or (can_mega or can_hover)) and
+                (Boss_Key_Fire_Temple or (glitch_bk_skip_fire and can_hover and glitch_insane and can_use(Goron_Tunic)))"
+        }
+    },
+    {
+        "region_name": "Fire Temple Boss Room",
+        "dungeon": "Fire Temple",
+        "locations": {
+            "Fire Temple Volvagia Heart": "can_use(Megaton_Hammer) and (can_use(Goron_Tunic) or
+                (glitch_hard_bosses and Fairy and has_explosives))",
+            "Volvagia": "can_use(Megaton_Hammer) and (can_use(Goron_Tunic) or
+                (glitch_hard_bosses and Fairy and has_explosives))"
         }
     },
     {
@@ -27,40 +35,44 @@
         "locations": {
             "Fire Temple Big Lava Room Lower Open Door Chest": "True",
             "Fire Temple Big Lava Room Blocked Door Chest": "has_explosives",
+            # Hovering would take too long for child to reasonably do this
             "Fire Temple GS Song of Time Room": "is_adult"
         },
         "exits": {
             "Fire Temple Lower":  "True",
-            "Fire Temple Middle": "
-                (can_use(Goron_Tunic) or Fairy) and (Small_Key_Fire_Temple, 4) and 
-                (has_explosives or can_use(Bow) or can_use(Hookshot))"
+            # End of the logical line for child. You can't even climb the fence in 24 seconds.
+            "Fire Temple Boulder Maze Lower": "can_use(Goron_Tunic) and (Small_Key_Fire_Temple, 4) and can_use_projectile",
+            "Fire Temple Boulder Maze Upper": "can_use(Goron_Tunic) and (Small_Key_Fire_Temple, 4) and (has_explosives and can_live_dmg(0.5))"
         }
     },
     {
-        "region_name": "Fire Temple Middle",
+        "region_name": "Fire Temple Boulder Maze Lower",
         "dungeon": "Fire Temple",
         "locations": {
             "Fire Temple Boulder Maze Lower Chest": "True",
-            "Fire Temple Boulder Maze Upper Chest": "(Small_Key_Fire_Temple, 6)
-                or (has_explosives and can_live_dmg(0.5) and (Small_Key_Fire_Temple, 4))",
             "Fire Temple Boulder Maze Side Room Chest": "True",
-            "Fire Temple Boulder Maze Shortcut Chest": "((Small_Key_Fire_Temple, 6) and has_explosives) or
-                (((has_explosives and can_live_dmg(0.5)) or can_weirdshot) and (Small_Key_Fire_Temple, 4))",
-            "Fire Temple Scarecrow Chest": "(
-                (Small_Key_Fire_Temple, 6) or (has_explosives and can_live_dmg(0.5) and (Small_Key_Fire_Temple, 4)) ) 
-                and (can_use(Scarecrow) or can_hover)",
-            "Fire Temple Map Chest": "
-                (Small_Key_Fire_Temple, 6) or ((Small_Key_Fire_Temple, 5) and can_use(Bow)) or 
-                (has_explosives and can_live_dmg(0.5) and (Small_Key_Fire_Temple, 4))",
-            "Fire Temple GS Boulder Maze": "(Small_Key_Fire_Temple, 4) and has_explosives",
-            "Fire Temple GS Scarecrow Climb": "(
-                (Small_Key_Fire_Temple, 6) or (has_explosives and can_live_dmg(0.5) and (Small_Key_Fire_Temple, 4)) ) 
-                and (can_use(Scarecrow) or can_hover)",
-            "Fire Temple GS Scarecrow Top": "(
-                (Small_Key_Fire_Temple, 6) or (has_explosives and can_live_dmg(0.5) and (Small_Key_Fire_Temple, 4)) ) 
-                and (can_use(Scarecrow) or can_hover)"
+            "Fire Temple Map Chest": "((Small_Key_Fire_Temple, 5) and can_use(Bow)) or
+                at('Fire Temple Boulder Maze Upper', True)",
+            "Fire Temple Boulder Maze Shortcut Chest": "at('Fire Temple Boulder Maze Upper', has_explosives) or
+                (can_weirdshot and can_use(Hookshot))",
+            "Fire Temple GS Boulder Maze": "has_explosives"
         },
         "exits": {
+            "Fire Temple Big Lava Room": "True",
+            "Fire Temple Boulder Maze Upper": "can_hover or (Small_Key_Fire_Temple, 6)"
+        }
+    },
+    {
+        "region_name": "Fire Temple Boulder Maze Upper",
+        "dungeon": "Fire Temple",
+        "locations": {
+            "Fire Temple Boulder Maze Upper Chest": "True",
+            "Fire Temple Scarecrow Chest": "can_use(Scarecrow) or can_hover or can_use(Longshot)",
+            "Fire Temple GS Scarecrow Climb": "can_use(Scarecrow) or can_hover or can_use(Longshot)",
+            "Fire Temple GS Scarecrow Top": "can_use(Scarecrow) or can_hover or can_use(Longshot)"
+        },
+        "exits": {
+            "Fire Temple Boulder Maze Lower": "True",
             "Fire Temple Flame Maze": "(Small_Key_Fire_Temple, 7)"
         }
     },
@@ -68,29 +80,24 @@
         "region_name": "Fire Temple Flame Maze",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple Compass Chest": "(Small_Key_Fire_Temple, 7)"
+            "Fire Temple Compass Chest": "True"
         },
         "exits": {
-            "Fire Temple Upper": "(Small_Key_Fire_Temple, 7)"
+            "Fire Temple Upper": "True"
         }
     },
     {
         "region_name": "Fire Temple Upper",
         "dungeon": "Fire Temple",
         "locations": {
-            "Fire Temple Highest Goron Chest": "(
-                can_use(Megaton_Hammer) or (has_explosives and can_live_dmg(1.0))
-                ) or
-                (
-                    (can_mega and can_use(Hookshot)) or 
-                    (can_play(Song_of_Time) and
-                        (can_use(Megaton_Hammer) or can_use(Hover_Boots) or (has_explosives and can_live_dmg(0.5)) )
-                    )
-
-                )
-                ",
-            "Fire Temple Megaton Hammer Chest": "has_explosives or
-                can_use(Megaton_Hammer)"
+            # Weirdshot, or sidehop from the hammer chest (can jumpslash to avoid damage in OHKO), or ledge clip using the SoT block
+            "Fire Temple Highest Goron Chest": "(can_weirdshot and Hookshot) or can_use(Megaton_Hammer) or
+                (can_play(Song_of_Time) and (can_use(Hover_Boots) or can_damage_boost))",
+            "Fire Temple Megaton Hammer Chest": "has_explosives or can_use(Megaton_Hammer)"
+        },
+        "exits": {
+            "Fire Temple Boss Room": "glitch_bk_skip_fire and
+                ((can_use(Megaton_Hammer) and can_use(Hover_Boots)) or can_bomb_slide)"
         }
     }
 ]

--- a/data/Glitched World/Jabu Jabus Belly.json
+++ b/data/Glitched World/Jabu Jabus Belly.json
@@ -46,8 +46,8 @@
         "dungeon": "Jabu Jabus Belly",
         "locations": {
             # Barinade can be killed using 5 pots. Tricky, since pots are scarce and getting hit drops and destroys the pot.
-            "Jabu Jabus Belly Barinade Heart": "can_use(Boomerang) and (can_jumpslash or glitch_insane)",
-            "Barinade": "can_use(Boomerang) and (can_jumpslash or glitch_insane)",
+            "Jabu Jabus Belly Barinade Heart": "can_use(Boomerang) and (can_jumpslash or glitch_hard_bosses)",
+            "Barinade": "can_use(Boomerang) and (can_jumpslash or glitch_hard_bosses)",
             "Jabu Jabus Belly GS Near Boss": "True"
         },
         "exits": {

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -57,7 +57,7 @@
             "Lost Woods": "True",
             # Triple slash clip, or Walking While Talking, or stick WESS or itemless
             "LW Bridge From Forest": "can_leave_forest or
-                (glitch_forest_escape and (Kokiri_Sword or Nuts or (glitch_hess and Sticks) or glitch_insane))",
+                (glitch_forest_escape and (Kokiri_Sword or Nuts or can_wess or glitch_insane))",
             "KF Storms Grotto": "can_play(Song_of_Storms)"
         }
     },
@@ -76,7 +76,9 @@
         },
         "exits": {
             #// Adult would technically come from Kokiri Forest, but the transition in both directions is True
-            "Deku Tree Lobby": "is_child or (shuffle_dungeon_entrances and 'Showed Mido Sword & Shield') or glitch_deku_entry",
+            "Deku Tree Lobby": "is_child or 
+                (is_adult and (shuffle_dungeon_entrances and 'Showed Mido Sword & Shield') or
+                (glitch_deku_entry and ((can_live_dmg(0.5) and has_explosives) or Hover_Boots)))",
             # There are other ways past this, but the only way to get to this side as a logical passage is to do reverse spirit, which means you hovered.
             "Kokiri Forest": "'Showed Mido Sword & Shield' or is_adult or (glitch_mido_skip and can_hover)"
         }
@@ -189,7 +191,7 @@
         "exits": {
             "LW Forest Exit": "True",
             # Adult can use bomb push from the back
-            "Lost Woods": "is_child or at('Lost Woods', can_play(Sarias_Song)) or can_hess or (can_use(Hover_Boots) and can_shield) or (Bombs and can_shield)",
+            "Lost Woods": "is_child or at('Lost Woods', can_play(Sarias_Song)) or can_bomb_slide or (can_use(Hover_Boots) and can_shield) or (Bombs and can_shield)",
             "SFM Entryway": "True",
             "Deku Theater": "True",
             "LW Scrubs Grotto": "can_blast_or_smash"
@@ -528,8 +530,8 @@
         "locations": {
             "Colossus Freestanding PoH": "
                 (is_adult and here(can_plant_bean)) or
-                at('Mirror Shield Hand', (can_mega or (can_hess and can_use(Hover_Boots)))) or
-                at('Silver Gauntlets Hand', (can_mega or (can_hess and can_use(Hover_Boots)))) or
+                at('Mirror Shield Hand', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
+                at('Silver Gauntlets Hand', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
                 (can_hover and (can_use(Hover_Boots) or can_qpa or glitch_insane))",
             "Sheik at Colossus": "True",
             "Colossus GS Bean Patch": "can_plant_bugs and can_child_attack",
@@ -711,7 +713,7 @@
                 (has_explosives and (can_live_dmg(0.5) or can_use(Nayrus_Love))) or (can_use(Hover_Boots) and (can_shield or can_use(Megaton_Hammer))) or glitch_insane)",
             # Bomb hover or hoverboots hess across
             "Ganons Castle Lobby": "can_build_rainbow_bridge or
-                (glitch_bridge_skip and (can_hover or (can_hess and can_use(Hover_Boots))))"
+                (glitch_bridge_skip and (can_hover or (can_bomb_slide and can_use(Hover_Boots))))"
         }
     },
     {
@@ -942,8 +944,6 @@
         }
     },
     {
-    # UPDATE: These three areas should be a special interior, but it can't be split, so I did some stuff in EntranceShuffle.py to at least fix them to the same hint region
-    # on glitch and no logic. Partially because it solves the special interior problem well enough for me, and partially because the heart piece is accessible from both sides.
         "region_name": "Kak Impas House",
         "exits": {
             "Kakariko Village": "True",
@@ -1115,7 +1115,7 @@
         "exits": {
             "Graveyard": "True",
             "Kak Windmill": "(is_child and can_groundjump) or 
-                (is_adult and (can_play(Song_of_Time) or can_hess or (has_explosives and can_live_dmg(0.5))))"
+                (is_adult and (can_play(Song_of_Time) or can_bomb_slide or (has_explosives and can_live_dmg(0.5))))"
         }
     },
     {
@@ -1228,22 +1228,22 @@
         "hint": "Goron City",
         "events": {
             "GC Woods Warp Open": "
-                can_blast_or_smash or can_use(Dins_Fire) or can_use(Bow) or Progressive_Strength_Upgrade or Blue_Fire",
+                can_blast_or_smash or can_use(Dins_Fire) or can_use(Bow) or Progressive_Strength_Upgrade or Blue_Fire or can_qpa",
             "Stop GC Rolling Goron as Adult": "is_adult and 
-                (Progressive_Strength_Upgrade or has_explosives or Bow or can_use(Dins_Fire) or Blue_Fire)"
+                (Progressive_Strength_Upgrade or has_explosives or Bow or can_use(Dins_Fire) or Blue_Fire or can_qpa)"
         },
         "locations": {
             # Hover backwalk from left chest, or hess using bomb flowers (strength or sticks work), or intended strats.
             "GC Maze Left Chest": "
                 can_use(Megaton_Hammer) or can_use(Silver_Gauntlets) or
-                ((Progressive_Strength_Upgrade or has_explosives or at('GC Darunias Chamber', is_child)) and can_shield and glitch_hess) or
+                ((Progressive_Strength_Upgrade or has_explosives or at('GC Darunias Chamber', is_child)) and can_shield and glitch_slide) or
                 (has_explosives and can_use(Hover_Boots)) or at('GC Darunias Chamber', can_ledge_cancel)",
             "GC Maze Center Chest": "
                 can_blast_or_smash or can_use(Silver_Gauntlets) or ((Progressive_Strength_Upgrade or at('GC Darunias Chamber', is_child))
-                    and can_shield and glitch_hess)",
+                    and can_shield and glitch_slide)",
             "GC Maze Right Chest": "
                 can_blast_or_smash or can_use(Silver_Gauntlets) or ((Progressive_Strength_Upgrade or at('GC Darunias Chamber', is_child))
-                    and can_shield and glitch_hess)",
+                    and can_shield and glitch_slide)",
             "GC Pot Freestanding PoH": "is_child and 
                 (has_explosives or Progressive_Strength_Upgrade) and 
                 (((can_play(Zeldas_Lullaby) or can_shield) and Sticks) or can_use(Dins_Fire) or can_qpa)",
@@ -1253,16 +1253,16 @@
             "GC Medigoron": "is_adult and Progressive_Wallet and
                 here(can_blast_or_smash or Progressive_Strength_Upgrade or (glitch_insane and Blue_Fire))",
             # Sticks are always True in GC, so no point in checking for strength for this hess
-            "GC GS Boulder Maze": "is_child and (can_blast_or_smash or (can_shield and glitch_hess))",
+            "GC GS Boulder Maze": "is_child and (can_blast_or_smash or (can_shield and glitch_slide))",
             "GC GS Center Platform": "is_adult",
             "GC Maze Gossip Stone": "can_blast_or_smash or can_use(Silver_Gauntlets) or
-                ((Progressive_Strength_Upgrade or at('GC Darunias Chamber', is_child)) and can_shield and glitch_hess)",
+                ((Progressive_Strength_Upgrade or at('GC Darunias Chamber', is_child)) and can_shield and glitch_slide)",
             "GC Medigoron Gossip Stone": "can_blast_or_smash or Progressive_Strength_Upgrade or (glitch_insane and Blue_Fire)",
             "Gossip Stone Fairy": "
                 can_summon_gossip_fairy_without_suns and has_bottle and
                 (can_blast_or_smash or Progressive_Strength_Upgrade or (glitch_insane and Blue_Fire))",
             "Bug Rock": "has_bottle and (can_blast_or_smash or can_use(Silver_Gauntlets) or
-                ((Progressive_Strength_Upgrade or at('GC Darunias Chamber', is_child)) and can_shield and glitch_hess))",
+                ((Progressive_Strength_Upgrade or at('GC Darunias Chamber', is_child)) and can_shield and glitch_slide))",
             "Stick Pot": "is_child"
         },
         "exits": {
@@ -1285,7 +1285,7 @@
     {
         "region_name": "GC Woods Warp",
         "events": {
-            "GC Woods Warp Open": "can_blast_or_smash or can_use(Dins_Fire)"
+            "GC Woods Warp Open": "can_blast_or_smash or can_use(Dins_Fire) or (is_adult and can_qpa and Biggoron_Sword)"
         },
         "exits": {
             "Goron City": "(can_leave_forest or glitch_forest_escape) and 'GC Woods Warp Open'",
@@ -1306,7 +1306,7 @@
             # UPDATE: I vaguely remember something about a triple slash clip here...not sure if I'm wrong though.
             # Child can use heap fragmentation to unload the statue.
             "DMC Lower Nearby": "is_adult or
-                (glitch_stairs or can_hess or (Bombs and (can_live_dmg(0.5) or can_use(Nayrus_Love))))"
+                (glitch_stairs or can_bomb_slide or (Bombs and (can_live_dmg(0.5) or can_use(Nayrus_Love))))"
         }
     },
     {
@@ -1385,7 +1385,7 @@
             "DMC Lower Local": "can_use(Goron_Tunic)",
             "GC Darunias Chamber": "True",
             # Child can just sidehop through
-            "DMC Great Fairy Fountain": "can_use(Megaton_Hammer) or can_hess or is_child",
+            "DMC Great Fairy Fountain": "can_use(Megaton_Hammer) or can_bomb_slide or is_child",
             "DMC Hammer Grotto": "can_use(Megaton_Hammer) or can_weirdclip",
             "DMC Central Nearby": "can_use(Hover_Boots) or can_use(Hookshot) or can_mega"
         }
@@ -1627,7 +1627,7 @@
         "scene": "Lon Lon Ranch",
         "hint": "Lon Lon Ranch",
         "events": {
-            "Epona": "(can_play(Eponas_Song) or can_hover or (can_hess and can_use(Hover_Boots) and glitch_insane)) and is_adult",
+            "Epona": "(can_play(Eponas_Song) or can_hover or (can_bomb_slide and can_use(Hover_Boots) and glitch_insane)) and is_adult",
             "Links Cow": "(can_play(Eponas_Song) or can_hover) and is_adult"
         },
         "locations": {

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -77,7 +77,7 @@
     "_is_magic_item(item)": "item == Dins_Fire or item == Farores_Wind or item == Nayrus_Love or item == Lens_of_Truth",
     "_is_adult_item(item)": "item == Bow or item == Megaton_Hammer or item == Iron_Boots or item == Hover_Boots or item == Hookshot or item == Longshot or item == Silver_Gauntlets or item == Golden_Gauntlets or item == Goron_Tunic or item == Zora_Tunic or item == Scarecrow or item == Distant_Scarecrow",
     "_is_child_item(item)": "item == Slingshot or item == Boomerang or item == Kokiri_Sword or item == Sticks or item == Deku_Shield",
-    "_is_magic_arrow(item)": "item == Fire_Arrows or item == Light_Arrows",
+    "_is_magic_arrow(item)": "item == Fire_Arrows or item == Ice_Arrows or item == Light_Arrows",
     "_is_equipswap_item(item)": "item == Megaton_Hammer or item == Boomerang or item == Sticks",
     # Slingshot as adult requires quiver so it needs to specifically check for that.
     "_is_equipswap_slingshot(item)": "item == Slingshot",
@@ -116,8 +116,8 @@
     "can_oi": "(Fish or Bugs) and glitch_oi",
     "can_groundjump": "can_shield and Bombs",
     "can_equipswap": "(Dins_Fire or (is_child and Sticks)) and glitch_equipswap",
-    "can_hess": "has_explosives and can_shield and glitch_hess",
-    "can_wess": "can_jumpslash and glitch_hess",
+    "can_bomb_slide": "has_explosives and can_shield and glitch_slide",
+    "can_wess": "can_jumpslash and glitch_slide",
     # This can also be done with a ledge, but that's better to define on-location rather than with a helper.
     "can_qpa": "glitch_qpa and can_use(Sticks) and (has_cutscene_item or Nuts)",
     # Chus are hard to work with without something specific to blow them up on (e.g. King Zora's sign).


### PR DESCRIPTION
Includes the following changes:
 - Updates Fire Temple for glitch logic 2.0
 - Adds the "Bosses With Unusual Items" toggle, and adds it to Dodongo and Jabu (Handles issue #11)
 - Changes mentions of "HESS" to "Bomb Slide", except where an actual HESS is actually required (Currently only for fire BK skip). Affects settingslist.py, overworld.json, and dodongos cavern.json
 - Changes the "Superslides" toggle to "All Superslides"
 - Rewrites the Fire BK skip description to actually exist, although the description still needs some extra work to not suck
 - Adds in the logic helper `can_use(Ice_Arrows)`, for future use
 - Adds a couple missed QPAs to Goron City
 - Cleans up the description of a couple of toggles.
 - Changes the logic for WESS escape to actually just be `can_wess`.