### PR TITLE
July 9th update

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -580,6 +580,39 @@ logic_glitches = {
                     If All Uses Enabled is on and bomb hovers are in logic, then
                     this also puts Phantom Ganon without projectiles in logic.
                     '''},
+    # UPDATE: I'm really not sure on whether this should be default or not.
+    # It's a trick in the meantime, until I figure it out.
+    'Shared Flag Abuse': {
+        'name'    : 'glitch_shared_flags',
+        'tags'    : ("General",),
+        'tooltip' : '''\
+                    In some dungeons, flags between two unrelated actions are
+                    shared. You can abuse this to complete some actions (e.g.
+                    opening the first silver rupee gate in Shadow) by doing
+                    the shared, unrelated action (e.g. Killing the two redeads
+                    in the invisible spikes room).
+                    '''},
+    'Climb the Shadow Boat as Child': {
+        'name'   : 'glitch_shadow_boat',
+        'tags'   : ("Shadow Temple",),
+        'tooltip' : '''\
+                    With very careful movement, you can jump to the bell
+                    as child. From there, you can clip partially into the boat,
+                    giving you just enough height to damage boost onto the wheel,
+                    allowing you to jump onto the boat itself.
+                    
+                    Requires damage boosts to be in logic.
+                    '''},
+    'Reach Shadow Boat GS with Nothing': {
+        'name'    : 'glitch_shadow_boat_gs',
+        'tags'    : ("Shadow Temple", "Skulltulas",),
+        'tooltip' : '''\
+                    By using a specific cage clip and a twisted sideroll, you
+                    can reach the platform where the shadow boat GS is.
+                    
+                    You will still need hookshot, boomerang, or to ground jump
+                    to actually grab the skull.
+                    '''},
 }
 
 logic_tricks = {

--- a/data/Glitched World/Bottom of the Well.json
+++ b/data/Glitched World/Bottom of the Well.json
@@ -25,9 +25,8 @@
                 ((Small_Key_Bottom_of_the_Well, 3) and glitch_actor)",
             "Bottom of the Well Underwater Front Chest": "can_play(Zeldas_Lullaby)",
             "Bottom of the Well Underwater Left Chest": "can_play(Zeldas_Lullaby)",
-            # Technically requires a fire source w/torch or 3 keys, but there's a stick pot.
-            "Bottom of the Well Map Chest": "has_explosives or
-                Progressive_Strength_Upgrade",
+            # Use WWT from the face sign near the crawlspace
+            "Bottom of the Well Map Chest": "True",
             "Bottom of the Well Fire Keese Chest": "
                 (Small_Key_Bottom_of_the_Well, 3)",
             "Bottom of the Well Like Like Chest": "

--- a/data/Glitched World/Deku Tree.json
+++ b/data/Glitched World/Deku Tree.json
@@ -9,15 +9,18 @@
             "Deku Tree Basement Chest": "is_adult or can_child_attack or Nuts",
             "Deku Tree GS Compass Room": "is_adult or can_child_attack",
             "Deku Tree GS Basement Vines": "is_adult or can_child_attack",
-            "Deku Tree GS Basement Gate": "is_adult or can_child_attack"
+            "Deku Tree GS Basement Gate": "is_adult or can_child_attack",
+            "Deku Baba Sticks": "is_adult or Kokiri_Sword or Boomerang or can_isg",
+            "Deku Baba Nuts": "can_jumpslash or can_use(Megaton_Hammer) or
+                has_explosives or can_use(Dins_Fire)"
         },
         "exits": {
             "Deku Tree Slingshot Room": "here(has_shield) or can_use(Hammer)",
             "Deku Tree Basement Backroom": "is_child or (here(can_use(Slingshot) or can_use(Bow)) and here(has_fire_source_with_torch or can_use(Bow))) or
                 (glitch_deku_crawlspace and can_hover and can_use(Hookshot))",
-            "Deku Tree Boss Room": "(here((has_fire_source_with_torch or can_use(Bow)) or (can_weirdshot and can_use(Hookshot))) and
-                    (has_shield or can_use(Hammer))) or
-                (is_adult and glitch_gohma_skip)"
+            "Deku Tree Before Boss": "here(has_fire_source_with_torch or can_use(Bow)) or (can_weirdshot and can_use(Hookshot))",
+            "Deku Tree Boss Room": "is_adult and glitch_gohma_skip",
+            "KF Outside Deku Tree": "True"
         }
     },
     {
@@ -42,17 +45,28 @@
         }
     },
     {
+        "region_name": "Deku Tree Before Boss",
+        "dungeon": "Deku Tree",
+        "exits": {
+            "Deku Tree Lobby": "True",
+            "Deku Tree Boss Room": "here(has_shield or can_use(Megaton_Hammer))"
+        }
+    },
+    {
         "region_name": "Deku Tree Boss Room",
         "dungeon": "Deku Tree",
         "events": {
-            "Deku Tree Clear": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and
-                ((here(has_shield or can_use(Megaton_Hammer)) and (is_adult or Kokiri_Sword or Sticks)) or is_adult)"
+            "Deku Tree Clear": "(can_qpa and can_isg) or
+                ((can_jumpslash or can_use(Megaton_Hammer)) and
+                (Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)))"
         },
         "locations": {
-            "Deku Tree Queen Gohma Heart": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and 
-                ((here(has_shield or can_use(Megaton_Hammer)) and (is_adult or Kokiri_Sword or Sticks)) or is_adult)",
-            "Queen Gohma": "(Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)) and
-                ((here(has_shield or can_use(Megaton_Hammer)) and (is_adult or Kokiri_Sword or Sticks)) or is_adult)"
+            "Deku Tree Queen Gohma Heart": "(can_qpa and can_isg) or
+                ((can_jumpslash or can_use(Megaton_Hammer)) and
+                (Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)))",
+            "Queen Gohma": "(can_qpa and can_isg) or
+                ((can_jumpslash or can_use(Megaton_Hammer)) and
+                (Nuts or can_use(Slingshot) or has_bombchus or can_use(Hookshot) or can_use(Bow) or can_use(Boomerang)))"
         },
         "exits": {
             "Deku Tree Lobby": "True"

--- a/data/Glitched World/Dodongos Cavern.json
+++ b/data/Glitched World/Dodongos Cavern.json
@@ -3,9 +3,9 @@
         "region_name": "Dodongos Cavern Beginning",
         "dungeon": "Dodongos Cavern",
         "exits": {
-            "Dodongos Cavern Entryway": "True",
             "Dodongos Cavern Lobby": "
-                here(can_blast_or_smash) or Blue_Fire or Progressive_Strength_Upgrade"
+                here(can_blast_or_smash) or Blue_Fire or Progressive_Strength_Upgrade",
+            "Death Mountain": "True"
         }
     },
     {

--- a/data/Glitched World/Fire Temple.json
+++ b/data/Glitched World/Fire Temple.json
@@ -16,7 +16,8 @@
             "Fire Temple Big Lava Room":"(Small_Key_Fire_Temple, 2)",
             # Once boss shuffle is implemented, child can damage boost from the pillar after adult knocks it down.
             "Fire Temple Boss Room": "(is_adult or (can_mega or can_hover)) and
-                (Boss_Key_Fire_Temple or (glitch_bk_skip_fire and can_hover and glitch_insane and can_use(Goron_Tunic)))"
+                (Boss_Key_Fire_Temple or (glitch_bk_skip_fire and can_hover and glitch_insane and can_use(Goron_Tunic)))",
+            "DMC Fire Temple Entrance": "True"
         }
     },
     {

--- a/data/Glitched World/Forest Temple.json
+++ b/data/Glitched World/Forest Temple.json
@@ -19,7 +19,8 @@
             "Forest Temple Block Push Room": "(Small_Key_Forest_Temple, 1)",
             "Forest Temple Basement": "(Forest_Temple_Jo_and_Beth and Forest_Temple_Amy_and_Meg) or (can_use(Hover_Boots) and can_mega)",
             "Forest Temple Falling Room": "can_hover or (can_use(Hover_Boots) and Bombs and can_live_dmg(0.5))",
-            "Forest Temple Boss Room": "is_adult"
+            "Forest Temple Boss Room": "is_adult",
+            "SFM Forest Temple Entrance Ledge": "True"
         }
     },
     {

--- a/data/Glitched World/Gerudo Training Grounds.json
+++ b/data/Glitched World/Gerudo Training Grounds.json
@@ -13,7 +13,8 @@
             "Gerudo Training Grounds Heavy Block Room": "True",
             "Gerudo Training Grounds Lava Room": "
                 here(has_explosives and can_jumpslash)",
-            "Gerudo Training Grounds Central Maze": "True"
+            "Gerudo Training Grounds Central Maze": "True",
+            "Gerudo Fortress": "True"
         }
     },
     {

--- a/data/Glitched World/Ice Cavern.json
+++ b/data/Glitched World/Ice Cavern.json
@@ -1,9 +1,11 @@
 [
-    {   ##Child must be able to hover to get in here so can_hover is always true as child
+    {   # UPDATE: THIS IS NOT TRUE ANYMORE
+		##Child must be able to hover to get in here so can_hover is always true as child
         "region_name": "Ice Cavern Beginning",
         "dungeon": "Ice Cavern",
         "exits": {
-            "Ice Cavern": "is_adult or Sticks or can_use(Dins_Fire)"
+            "Ice Cavern": "is_adult or Sticks or can_use(Dins_Fire)",
+			"ZF Ice Ledge": "True"
         }
     },
     {

--- a/data/Glitched World/Ice Cavern.json
+++ b/data/Glitched World/Ice Cavern.json
@@ -1,11 +1,11 @@
 [
     {   # UPDATE: THIS IS NOT TRUE ANYMORE
-		##Child must be able to hover to get in here so can_hover is always true as child
+        ##Child must be able to hover to get in here so can_hover is always true as child
         "region_name": "Ice Cavern Beginning",
         "dungeon": "Ice Cavern",
         "exits": {
             "Ice Cavern": "is_adult or Sticks or can_use(Dins_Fire)",
-			"ZF Ice Ledge": "True"
+            "ZF Ice Ledge": "True"
         }
     },
     {

--- a/data/Glitched World/Jabu Jabus Belly.json
+++ b/data/Glitched World/Jabu Jabus Belly.json
@@ -22,7 +22,7 @@
             "Jabu Jabus Belly Beginning": "True",
             "Jabu Jabus Belly Depths": "True",
             # Biri hover here isn't too bad. Just mash backflip. You can also megaflip off the biri.
-            # The 2nd part is for skipping the door. Setups I saw required sword for positioning or backflipping and dumping bugs/fish. Like OI, but no other item.
+            # The 2nd part is for skipping the box before the door. Setups I saw required sword for positioning or backflipping and dumping bugs/fish. Like OI, but no other item.
             "Jabu Jabus Belly Boss Area": "(can_use(Hover_Boots) or can_damage_boost or can_enemy_hover or can_enemy_mega) and
                 (can_jumpslash or Fish or Bugs)"
         }
@@ -46,8 +46,9 @@
         "dungeon": "Jabu Jabus Belly",
         "locations": {
             # Barinade can be killed using 5 pots. Tricky, since pots are scarce and getting hit drops and destroys the pot.
-            "Jabu Jabus Belly Barinade Heart": "can_use(Boomerang) and (can_jumpslash or glitch_hard_bosses)",
-            "Barinade": "can_use(Boomerang) and (can_jumpslash or glitch_hard_bosses)",
+			# He can also be killed with default damage crouch stabs from the hammer. Not actual hammer damage though unfortunately.
+            "Jabu Jabus Belly Barinade Heart": "can_use(Boomerang) and (can_jumpslash or can_isg or glitch_hard_bosses)",
+            "Barinade": "can_use(Boomerang) and (can_jumpslash or can_isg or glitch_hard_bosses)",
             "Jabu Jabus Belly GS Near Boss": "True"
         },
         "exits": {

--- a/data/Glitched World/Jabu Jabus Belly.json
+++ b/data/Glitched World/Jabu Jabus Belly.json
@@ -46,7 +46,7 @@
         "dungeon": "Jabu Jabus Belly",
         "locations": {
             # Barinade can be killed using 5 pots. Tricky, since pots are scarce and getting hit drops and destroys the pot.
-			# He can also be killed with default damage crouch stabs from the hammer. Not actual hammer damage though unfortunately.
+            # He can also be killed with default damage crouch stabs from the hammer. Not actual hammer damage though unfortunately.
             "Jabu Jabus Belly Barinade Heart": "can_use(Boomerang) and (can_jumpslash or can_isg or glitch_hard_bosses)",
             "Barinade": "can_use(Boomerang) and (can_jumpslash or can_isg or glitch_hard_bosses)",
             "Jabu Jabus Belly GS Near Boss": "True"

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -13,15 +13,62 @@
     {
         "region_name": "Root Exits",
         "exits": {
-            "KF Links House": "is_child",
-            "Temple of Time": "
-                is_adult or 
-                (can_play(Prelude_of_Light) and can_leave_forest)",
-            "Sacred Forest Meadow": "can_play(Minuet_of_Forest)",
-            "DMC Central Local": "can_play(Bolero_of_Fire) and can_leave_forest",
-            "Lake Hylia": "can_play(Serenade_of_Water) and can_leave_forest",
-            "Graveyard Warp Pad Region": "can_play(Nocturne_of_Shadow) and can_leave_forest",
-            "Desert Colossus": "can_play(Requiem_of_Spirit) and can_leave_forest"
+            "Child Spawn": "is_child",
+            "Adult Spawn": "is_adult",
+            "Prelude of Light Warp": "can_play(Prelude_of_Light) and can_leave_forest",
+            "Minuet of Forest Warp": "can_play(Minuet_of_Forest)",
+            "Bolero of Fire Warp": "can_play(Bolero_of_Fire) and can_leave_forest",
+            "Serenade of Water Warp": "can_play(Serenade_of_Water) and can_leave_forest",
+            "Nocturne of Shadow Warp": "can_play(Nocturne_of_Shadow) and can_leave_forest",
+            "Requiem of Spirit Warp": "can_play(Requiem_of_Spirit) and can_leave_forest"
+        }
+    },
+    {
+        "region_name": "Child Spawn",
+        "exits": {
+            "KF Links House": "True"
+        }
+    },
+    {
+        "region_name": "Adult Spawn",
+        "exits": {
+            "Temple of Time": "True"
+        }
+    },
+    {
+        "region_name": "Prelude of Light Warp",
+        "exits": {
+            "Temple of Time": "True"
+        }
+    },
+    {
+        "region_name": "Minuet of Forest Warp",
+        "exits": {
+            "Sacred Forest Meadow": "True"
+        }
+    },
+    {
+        "region_name": "Bolero of Fire Warp",
+        "exits": {
+            "DMC Central Local": "True"
+        }
+    },
+    {
+        "region_name": "Serenade of Water Warp",
+        "exits": {
+            "Lake Hylia": "True"
+        }
+    },
+    {
+        "region_name": "Nocturne of Shadow Warp",
+        "exits": {
+            "Graveyard Warp Pad Region": "True"
+        }
+    },
+    {
+        "region_name": "Requiem of Spirit Warp",
+        "exits": {
+            "Desert Colossus": "True"
         }
     },
     {
@@ -77,8 +124,7 @@
         "exits": {
             #// Adult would technically come from Kokiri Forest, but the transition in both directions is True
             "Deku Tree Lobby": "is_child or 
-                (is_adult and (shuffle_dungeon_entrances and 'Showed Mido Sword & Shield') or
-                (glitch_deku_entry and ((can_live_dmg(0.5) and has_explosives) or Hover_Boots)))",
+                ((shuffle_dungeon_entrances and 'Showed Mido Sword & Shield') or glitch_deku_entry)",
             # There are other ways past this, but the only way to get to this side as a logical passage is to do reverse spirit, which means you hovered.
             "Kokiri Forest": "'Showed Mido Sword & Shield' or is_adult or (glitch_mido_skip and can_hover)"
         }
@@ -158,7 +204,7 @@
             "LW Skull Kid": "is_child and can_play(Sarias_Song)",
             "LW Ocarina Memory Game": "is_child and (Ocarina or can_oi)",
             # Adult cannot get this, even with equipswap.
-            "LW Target in Woods": "(can_use(Slingshot) or (can_qpa and can_hover)) and is_child",
+            "LW Target in Woods": "is_child and (can_use(Slingshot) or (can_qpa and can_hover))",
             "LW Deku Scrub Near Bridge": "is_child and can_stun_deku",
             "LW GS Bean Patch Near Bridge": "can_plant_bugs and can_child_attack",
             "LW Gossip Stone": "True",
@@ -211,6 +257,7 @@
     },
     {
         "region_name": "Sacred Forest Meadow",
+        "scene": "Sacred Forest Meadow",
         "hint": "Sacred Forest Meadow",
         "locations": {
             "Song from Saria": "is_child and Zeldas_Letter",
@@ -222,9 +269,18 @@
         },
         "exits": {
             "SFM Entryway": "True",
-            "Forest Temple Lobby": "can_use(Hookshot) or can_hover",
+            "SFM Forest Temple Entrance Ledge": "can_use(Hookshot) or can_hover",
             "SFM Fairy Grotto": "True",
             "SFM Storms Grotto": "can_play(Song_of_Storms)"
+        }
+    },
+    {
+        "region_name": "SFM Forest Temple Entrance Ledge",
+        "scene": "Sacred Forest Meadow",
+        "hint": "Sacred Forest Meadow",
+        "exits": {
+            "Sacred Forest Meadow": "True",
+            "Forest Temple Lobby": "True"
         }
     },
     {
@@ -262,7 +318,7 @@
             "LW Bridge": "True",
             "Lake Hylia": "True",
             "Gerudo Valley": "True",
-            "Market": "True",
+            "Market Entrance": "True",
             "Kakariko Village": "True", 
             "ZR Front": "True",
             "Lon Lon Ranch": "True",
@@ -314,11 +370,20 @@
             "LH Owl Flight": "is_child",
             "LH Lab": "True",
             # Tektite hover is stupid hard
-            "LH Fishing Hole": "
+            "LH Fishing Island": "
                 is_child or can_use(Scarecrow) or here(can_plant_bean) or 'Water Temple Clear' or can_hover or (can_enemy_hover and glitch_insane)",
             # Adult can always lower water and navi dive after opening.
             "Water Temple Lobby": "can_use(Hookshot) or glitch_lab_clip",
             "LH Grotto": "True"
+        }
+    },
+    {
+        "region_name": "LH Fishing Island",
+        "scene": "Lake Hylia",
+        "hint": "Lake Hylia",
+        "exits": {
+            "Lake Hylia": "True",
+            "LH Fishing Hole": "True"
         }
     },
     {
@@ -354,7 +419,7 @@
             "LH Adult Fishing": "is_adult"
         },
         "exits": {
-            "Lake Hylia": "True"
+            "LH Fishing Island": "True"
         }
     },
     { 
@@ -487,6 +552,7 @@
         },
         "exits": {
         # Use antigrav from the HBA area for both of these. It unloads both gates.
+            "GV Fortress Side": "True",
             "GF Outside Gate": "True",
             "Gerudo Training Grounds Lobby": "True",
             "GF Storms Grotto": "is_adult and can_play(Song_of_Storms)"
@@ -502,6 +568,16 @@
         },
         "exits": {
             "Gerudo Fortress": "is_adult or can_hover or (shuffle_overworld_entrances and 'GF Gate Open')",
+            "Wasteland Near Fortress": "True"
+        }
+    },
+    # This needs to exist for ER reasons.
+    {
+        "region_name": "Wasteland Near Fortress",
+        "scene": "Haunted Wasteland",
+        "hint": "Haunted Wasteland",
+        "exits": {
+            "GF Outside Gate": "True",
             "Haunted Wasteland": "True"
         }
     },
@@ -518,8 +594,17 @@
             "Nut Pot": "True"
         },
         "exits": {
+            "Wasteland Near Fortress": "True",
+            "Wasteland Near Colossus": "True"
+        }
+    },
+    {
+        "region_name": "Wasteland Near Colossus",
+        "scene": "Haunted Wasteland",
+        "hint": "Haunted Wasteland",
+        "exits": {
             "Desert Colossus": "True",
-            "GF Outside Gate": "True"
+            "Haunted Wasteland": "True"
         }
     },
     {
@@ -533,7 +618,6 @@
                 at('Mirror Shield Hand', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
                 at('Silver Gauntlets Hand', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
                 (can_hover and (can_use(Hover_Boots) or can_qpa or glitch_insane))",
-            "Sheik at Colossus": "True",
             "Colossus GS Bean Patch": "can_plant_bugs and can_child_attack",
             "Colossus GS Tree": "is_adult and (can_use(Hookshot) or can_hover or can_use(Boomerang)) and at_night",
             "Colossus GS Hill": "is_adult and at_night",
@@ -543,6 +627,7 @@
             "Bug Rock": "has_bottle"
         },
         "exits": {
+            "Wasteland Near Colossus": "True",
             "Colossus Great Fairy Fountain": "has_explosives or (can_use(Hookshot) and can_use(Hover_Boots))",
             "Spirit Temple Lobby": "True",
             # This weirdclip is hard because sand is sand and leevers are a mistake.
@@ -557,6 +642,17 @@
                 (glitch_qpa and can_use(Sticks) and (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
                     (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))))) and
                 (here(can_plant_bean and is_adult) or (glitch_insane and has_bombchus))"
+        }
+    },
+    {
+        "region_name": "Desert Colossus From Spirit Lobby",
+        "scene": "Desert Colossus",
+        "hint": "Desert Colossus",
+        "locations": {
+            "Sheik at Colossus": "True"
+        },
+        "exits": {
+            "Desert Colossus": "True"
         }
     },
     {
@@ -591,10 +687,18 @@
             "Market Shooting Gallery": "is_child",
             "Market Bombchu Bowling": "is_child",
             "Market Potion Shop": "is_child and (at_day or Kokiri_Sword)",
-            "Market Treasure Chest Game": "is_child and (at_night or (Kokiri_Sword and glitch_treasure_day))",
-            "Market Bombchu Shop": "is_child and at_night",
-            "Market Dog Lady House": "is_child and at_night",
-            "Market Man in Green House": "is_child and at_night"
+            "Market Treasure Chest Game": "is_child and (at_night or (Kokiri_Sword and glitch_treasure_day))"
+        }
+    },
+    {
+        "region_name": "Market Back Alley",
+        "scene": "Market",
+        "hint": "the Market",
+        "exits": {
+            "Market": "True",
+            "Market Bombchu Shop": "at_night",
+            "Market Dog Lady House": "True",
+            "Market Man in Green House": "at_night"
         }
     },
     {
@@ -620,7 +724,7 @@
             "ToT Light Arrows Cutscene": "is_adult and can_trigger_lacs"
         },
         "exits": {
-            "Market": "True",
+            "ToT Entrance": "True",
             # Child can do this itemless, but to prevent softlocks he needs an item for adult to return. Check for the item BEFORE crossing the door.
             "Beyond Door of Time": "can_play(Song_of_Time) or open_door_of_time or
                 (((Hover_Boots and (Hylian_Shield or Mirror_Shield)) or Biggoron_Sword or Giants_Knife) and glitch_dot_skip)"
@@ -827,7 +931,7 @@
             "Market Bombchu Shop Item 8": "True"
         },
         "exits": {
-            "Market": "True"
+            "Market Back Alley": "True"
         }
     },
     {
@@ -836,13 +940,13 @@
             "Market Lost Dog": "True"
         },
         "exits": {
-            "Market": "True"
+            "Market Back Alley": "True"
         }
     },
     {
         "region_name": "Market Man in Green House",
         "exits": {
-            "Market": "True"
+            "Market Back Alley": "True"
         }
     },
     {
@@ -870,7 +974,6 @@
             "Kak GS Guards House": "is_child and at_night",
             "Kak GS Tree": "is_child and at_night",
             "Kak GS Watchtower": "'Killed Watchtower Skull'",
-            "Kak GS Above Impas House": "is_adult and (can_use(Hookshot) or can_use(Hover_Boots) or can_hover) and at_night",
             "Bug Rock": "has_bottle"
         },
         "exits": {
@@ -883,6 +986,7 @@
             # Chickens don't exist during the night.
             "Kak Impas Ledge": "is_adult or
                 (at_day or can_hover or can_mega)",
+            "Kak Impas Rooftop": "can_use(Hookshot) or can_use(Hover_Boots) or can_hover",
             "Kak Windmill": "True",
             "Kak Bazaar": "is_adult or (is_child and can_jumpslash)",
             # The clip in is trivial
@@ -896,7 +1000,7 @@
             "Kak Potion Shop Front": "is_child or at_day",
             "Kak Redead Grotto": "can_blast_or_smash",
             "Graveyard": "True",
-            "Death Mountain": "Zeldas_Letter or is_adult or open_kakariko == 'open' or can_hover"
+            "Kak Behind Gate": "Zeldas_Letter or is_adult or open_kakariko == 'open' or can_hover"
         }
     },
     {
@@ -905,6 +1009,18 @@
         "hint": "Kakariko Village",
         "exits": {
             "Kak Impas House Back": "True",
+            "Kakariko Village": "True"
+        }
+    },
+    {
+        "region_name": "Kak Impas Rooftop",
+        "scene": "Kakariko Village",
+        "hint": "Kakariko Village",
+        "locations": {
+            "Kak GS Above Impas House": "is_adult and at_night"
+        },
+        "exits": {
+            "Kak Impas Ledge": "True",
             "Kakariko Village": "True"
         }
     },
@@ -1043,7 +1159,7 @@
                 ('Odd Mushroom Access' or (Odd_Mushroom and disable_trade_revert))"
         },
         "exits": {
-            "Kakariko Village": "True"
+            "Kak Backyard": "True"
         }
     },
     {
@@ -1144,6 +1260,15 @@
         }
     },
     {
+        "region_name": "Kak Behind Gate",
+        "scene": "Kakariko Village",
+        "hint": "Kakariko Village",
+        "exits": {
+            "Kakariko Village": "True",
+            "Death Mountain": "True"
+        }
+    },
+    {
         "region_name": "Death Mountain",
         "scene": "Death Mountain",
         "hint": "Death Mountain Trail",
@@ -1171,12 +1296,12 @@
             "Bean Plant Fairy": "'Plant DMT Bean' and can_play(Song_of_Storms) and has_bottle"
         },
         "exits": {
-            "Kakariko Village": "True",
+            "Kak Behind Gate": "True",
             "Goron City": "True",
             "Death Mountain Summit": "here(can_blast_or_smash) or ('Plant DMT Bean' and is_adult) or
                 (is_child and can_enemy_hover and glitch_insane) or (can_use(Hookshot) and glitch_hookshot_jump) or can_use(Hover_Boots)",
             # There's a damageless entry from the summit.
-            "Dodongos Cavern Entryway": "
+            "Dodongos Cavern Beginning": "
                 has_explosives or Progressive_Strength_Upgrade or is_adult or ((can_live_dmg(0.5) or can_use(Nayrus_Love) or Fairy) and glitch_dodongo_entry)",
             "DMT Storms Grotto": "can_play(Song_of_Storms)"
         }
@@ -1206,21 +1331,14 @@
             # Seamwalk or triple slash.
             "DMT Great Fairy Fountain": "here(can_blast_or_smash) or can_isg or is_adult or Kokiri_Sword",
             # UPDATE: The vid I saw on this did jumpslashes for it, but I'm not sure if that's due to it being a 2011 vid or due to actually being needed. I'll test later
-            "Dodongos Cavern Entryway": "can_jumpslash and glitch_dodongo_entry"
+            "Dodongos Cavern Beginning": "can_jumpslash and glitch_dodongo_entry"
         }
     },
     {
         "region_name": "DMT Owl Flight",
         "scene": "Death Mountain",
         "exits": {
-            "Kak Impas Ledge": "True"
-        }
-    },
-    {
-        "region_name": "Dodongos Cavern Entryway",
-        "exits": {
-            "Dodongos Cavern Beginning": "True",
-            "Death Mountain": "True"
+            "Kak Impas Rooftop": "True"
         }
     },
     {
@@ -1305,7 +1423,7 @@
             "Goron City": "True",
             # UPDATE: I vaguely remember something about a triple slash clip here...not sure if I'm wrong though.
             # Child can use heap fragmentation to unload the statue.
-            "DMC Lower Nearby": "is_adult or
+            "DMC Lower Local": "is_adult or
                 (glitch_stairs or can_bomb_slide or (Bombs and (can_live_dmg(0.5) or can_use(Nayrus_Love))))"
         }
     },
@@ -1397,7 +1515,9 @@
         "exits": {
             "DMC Lower Nearby": "True",
             "DMC Ladder Area Nearby": "True",
-            "DMC Central Nearby": "can_use(Hover_Boots) or can_use(Hookshot) or can_mega"
+            "DMC Central Nearby": "can_use(Hover_Boots) or can_use(Hookshot) or can_mega",
+            # Megaflip to the volcano, then to the HP. Timer is very tight.
+            "DMC Fire Temple Entrance": "can_mega and can_live_dmg(0.5)"
         }
     },
     {
@@ -1428,12 +1548,11 @@
                 (can_use(Hover_Boots) or can_use(Hookshot) or here(can_plant_bean) or (can_use(Goron_Tunic) and can_hover))",
             "DMC Upper Nearby": "is_adult and here(can_plant_bean)",
             # Child takes 30+ seconds to get around this with an optimal hover from pad. Needs 4 hearts or a way to save at least 7 seconds
-            # UPDATE: dotzo is looking into this tomorrow.
-            "Fire Temple Entrance": "is_adult or (is_child and (shuffle_dungeon_entrances or can_mega))"
+            "DMC Fire Temple Entrance": "is_adult or shuffle_dungeon_entrances or can_damage_boost"
         }
     },
     {
-        "region_name": "Fire Temple Entrance",
+        "region_name": "DMC Fire Temple Entrance",
         "scene": "Death Mountain Crater",
         "hint": "Death Mountain Crater",
         "exits": {
@@ -1517,6 +1636,14 @@
         }
     },
     {
+        "region_name": "ZR Top of Waterfall",
+        "scene": "Zora River",
+        "hint": "Zora's River",
+        "exits": {
+            "Zora River": "True"
+        }
+    },
+    {
         "region_name": "Zoras Domain",
         "scene": "Zoras Domain",
         "hint": "Zora's Domain",
@@ -1548,6 +1675,14 @@
             "ZD Behind King Zora": "True",
             "ZD Shop": "True",
             "ZD Storms Grotto": "can_play(Song_of_Storms)"
+        }
+    },
+    {
+        "region_name": "ZD Eyeball Frog Timeout",
+        "scene": "Zoras Domain",
+        "hint": "Zora's Domain",
+        "exits": {
+            "Zoras Domain": "True"
         }
     },
     {
@@ -1899,7 +2034,7 @@
             "Nut Pot": "can_blast_or_smash or Blue_Fire"
         },
         "exits": {
-            "Hyrule Castle Grounds": "True"
+            "Castle Grounds": "True"
         }
     },
     {
@@ -1956,7 +2091,7 @@
             "GC Deku Scrub Grotto Center": "can_stun_deku"
         },
         "exits": {
-            "Goron City": "True"
+            "GC Grotto Platform": "True"
         }
     },
     {

--- a/data/Glitched World/Shadow Temple.json
+++ b/data/Glitched World/Shadow Temple.json
@@ -3,80 +3,112 @@
         "region_name": "Shadow Temple Entryway",
         "dungeon": "Shadow Temple",
         "exits": {
-            "Shadow Temple Beginning": "can_use(Hover_Boots) or can_use(Hookshot) or can_mega"
+            "Shadow Temple Beginning": "can_use(Hover_Boots) or can_use(Hookshot) or can_mega or can_hover",
+            "Graveyard Warp Pad Region": "True"
         }
     },
     {
         "region_name": "Shadow Temple Beginning",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Map Chest": "can_jumpslash or (can_use(Dins_Fire) and has_projectile(child))",
-            "Shadow Temple Hover Boots Chest": "can_jumpslash"
+            "Shadow Temple Map Chest": "can_jumpslash or can_use(Megaton_Hammer) or (can_use(Dins_Fire) and has_projectile(child))",
+            # Only hammer jumpslashes work.
+            "Shadow Temple Hover Boots Chest": "can_jumpslash or can_use(Megaton_Hammer)"
         },
         "exits": {
             "Shadow Temple Entryway": "True",
-            "Shadow Temple First Beamos": "can_use(Hover_Boots) or can_mega",
-            "Shadow Boss": "can_hover and has_explosives and can_use(Hover_Boots) and 
-                can_live_dmg(2.0)"
+            "Shadow Temple First Beamos": "can_use(Hover_Boots) or can_mega or can_hover",
+            # The megaflip clip won't work because it needs the hovers chest to be big and CSMC exists
+            "Shadow Boss": "glitch_bk_skip_shadow and is_adult and
+                ((can_hover and glitch_actor and can_use(Hover_Boots) and can_live_dmg(2.0) and glitch_insane) or
+                (can_bomb_slide and can_use(Hover_Boots)))"
         }
     },
     {
         "region_name": "Shadow Temple First Beamos",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Compass Chest": "can_jumpslash or can_use(Dins_Fire)",
-            "Shadow Temple Early Silver Rupee Chest": "is_adult or (is_child and can_hover)"
+            "Shadow Temple Compass Chest": "can_jumpslash or can_use(Megaton_Hammer) or can_use(Dins_Fire)",
+            "Shadow Temple Early Silver Rupee Chest": "is_adult or can_hover or
+                ('Invisible Spike Redeads' and glitch_shared_flags)"
         },
         "exits": {
-            "Shadow Temple Huge Pit": "has_explosives and (Small_Key_Shadow_Temple, 5)",
-            "Shadow Temple Boat": "can_jumpslash"
+        # Since the player can approach shadow from two directions at once (or rush the boss), we need to check for all keys.
+        # The central shadow doors (between here and boat) only need 4 since one of the doors never needs to be opened for anything.
+        # Of course, we still need to check for 5 at Bongo.
+            "Shadow Temple Huge Pit": "has_explosives and (Small_Key_Shadow_Temple, 4)",
+            "Shadow Temple Boat": "can_jumpslash or can_use(Megaton_Hammer)"
         }
     },
     {
         "region_name": "Shadow Temple Huge Pit",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Invisible Blades Visible Chest": "can_jumpslash or Slingshot",
-            "Shadow Temple Invisible Blades Invisible Chest": "can_jumpslash or Slingshot",
+            "Shadow Temple Invisible Blades Visible Chest": "can_jumpslash or can_use(Megaton_Hammer) or has_projectile(child)",
+            "Shadow Temple Invisible Blades Invisible Chest": "can_jumpslash or can_use(Megaton_Hammer) or has_projectile(child)",
+            # Both ages can backflip through the crushers
             "Shadow Temple Falling Spikes Lower Chest": "True",
-            "Shadow Temple Falling Spikes Upper Chest": "is_adult or can_hover",
-            "Shadow Temple Falling Spikes Switch Chest": "is_adult or can_hover",
-            "Shadow Temple Invisible Spikes Chest": "(Small_Key_Shadow_Temple, 5) and (can_jumpslash or can_use(Dins_Fire))",
-            "Shadow Temple Freestanding Key": "
-                (Small_Key_Shadow_Temple, 5) and (can_use(Hookshot) or can_hover) 
-                and (Progressive_Strength_Upgrade or has_explosives)",
-            "Shadow Temple GS Like Like Room": "is_adult or can_use(Boomerang) or can_hover",
-            "Shadow Temple GS Falling Spikes Room": "can_use(Hookshot) or (is_adult and can_mega) or (is_child and can_hover)",
-            "Shadow Temple GS Single Giant Pot": "(Small_Key_Shadow_Temple, 5) and (can_use(Hookshot) or can_hover)"
+            "Shadow Temple Falling Spikes Upper Chest": "True",
+            "Shadow Temple Falling Spikes Switch Chest": "True",
+            # If child is here they have bombs to kill the likelike.
+            "Shadow Temple GS Like Like Room": "is_adult or has_projectile(child) or can_hover",
+            "Shadow Temple GS Falling Spikes Room": "can_use(Hookshot) or can_use(Boomerang) or (is_adult and can_mega) or can_hover"
         },
         "exits": {
-            "Shadow Temple Wind Tunnel": "(can_use(Hookshot) or can_hover) and (Small_Key_Shadow_Temple, 5)"
+            "Shadow Temple Invisible Spikes": "True"
+        }
+    },
+    {
+        "region_name": "Shadow Temple Invisible Spikes",
+        "dungeon": "Shadow Temple",
+        "events" : {
+            "Invisible Spike Redeads": "can_jumpslash or can_use(Megaton_Hammer) or can_use(Dins_Fire)"
+        },
+        "locations": {
+            "Shadow Temple Invisible Spikes Chest": "'Invisible Spike Redeads'",
+            "Shadow Temple Freestanding Key": "(can_use(Hookshot) or can_hover) and (Progressive_Strength_Upgrade or has_explosives)",
+            "Shadow Temple GS Single Giant Pot": "can_use(Hookshot) or can_hover"
+        },
+        "exits": {
+            "Shadow Temple Huge Pit": "True",
+            "Shadow Temple Wind Tunnel": "can_use(Hookshot) or can_hover"
         }
     },
     {
         "region_name": "Shadow Temple Wind Tunnel",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Wind Hint Chest": "can_jumpslash or can_use(Dins_Fire)",
-            "Shadow Temple After Wind Enemy Chest": "can_jumpslash or can_use(Dins_Fire)",
+            "Shadow Temple Wind Hint Chest": "can_jumpslash or can_use(Megaton_Hammer) or can_use(Dins_Fire) or can_use(Megaton_Hammer)"
+        },
+        "exits": {
+            "Shadow Temple Invisible Spikes": "can_hover or can_use(Hookshot)",
+            "Shadow Temple After Wind": "True"
+        }
+    },
+    {
+        "region_name": "Shadow Temple After Wind",
+        "dungeon": "Shadow Temple",
+        "locations": {
+            "Shadow Temple After Wind Enemy Chest": "can_jumpslash or can_use(Megaton_Hammer) or can_use(Dins_Fire)",
             "Shadow Temple After Wind Hidden Chest": "has_explosives"
         },
         "exits": {
-            "Shadow Temple Boat": "(Small_Key_Shadow_Temple, 5)",
-            "Shadow Temple Huge Pit": "can_hover"
+        # Child needs to hover or mega, but this is already checked at the entrance.
+            "Shadow Temple Wind Tunnel": "True",
+            "Shadow Temple Boat": "True"
         }
     },
     {
         "region_name": "Shadow Temple Boat",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple GS Near Ship": "can_use(Longshot) or (can_use(Hover_Boots) and can_mega)
-                or (is_child and can_hover)"
+            "Shadow Temple GS Near Ship": "can_use(Longshot) or (can_use(Hover_Boots) and can_bomb_slide) or can_hover or 
+                (glitch_shadow_boat_gs and is_adult and can_shield and (can_groundjump or Hookshot or can_use(Boomerang)))"
         },
         "exits": {
-            "Shadow Temple Wind Tunnel": "(Small_Key_Shadow_Temple,5)",
+            "Shadow Temple After Wind": "(Small_Key_Shadow_Temple, 4)",
             "Shadow Temple Beyond Boat": "can_play(Zeldas_Lullaby) and
-                (is_adult or (is_child and can_hover))"
+                (is_adult or can_hover or (glitch_shadow_boat and can_shield and can_damage_boost))"
         }
     },
     {
@@ -84,25 +116,28 @@
         "dungeon": "Shadow Temple",
         "locations": {
             "Shadow Temple Spike Walls Left Chest": "can_use(Dins_Fire) or can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love) or
-                (can_use(Hookshot) and can_mega)",
+                (can_use(Hookshot) and can_weirdshot) or (can_qpa and can_isg)",
             "Shadow Temple Boss Key Chest": "can_use(Dins_Fire) or can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love) or
-                (can_use(Hookshot) and can_mega)",
+                (can_use(Hookshot) and can_weirdshot) or (can_qpa and can_isg)",
             "Shadow Temple Invisible Floormaster Chest": "True",
             "Shadow Temple GS Triple Giant Pot": "True"
         },
         "exits": {
-            "Shadow Boss": "(has_bombchus or can_use(Distant_Scarecrow) or Bow or 
-                (can_mega and can_use(Hover_Boots)) or can_hover) and 
-                (Boss_Key_Shadow_Temple or (has_explosives and is_adult)) and
-                (can_mega or can_use(Hover_Boots)) and (Small_Key_Shadow_Temple, 5)"
+            "Shadow Boss": "
+                (has_bombchus or can_use(Distant_Scarecrow) or Bow or (can_bomb_slide and can_use(Hover_Boots)) or can_hover) and
+                (Small_Key_Shadow_Temple, 5) and (can_mega or can_hover or can_use(Hover_Boots)) and
+                (Boss_Key_Shadow_Temple or (is_adult and glitch_bk_skip_shadow and (can_hover or (has_explosives and can_live_dmg(0.5)))))"
         }
     },
     {
         "region_name": "Shadow Boss",
         "dungeon": "Shadow Temple",
         "locations": {
-            "Shadow Temple Bongo Bongo Heart": "True",
-            "Bongo Bongo": "True"
+            # Hammer damage can't kill.
+            "Shadow Temple Bongo Bongo Heart": "(can_jumpslash or can_isg) and
+                (can_use(Hookshot) or can_use(Bow) or can_use(Slingshot) or glitch_hard_bosses)",
+            "Bongo Bongo": "(can_jumpslash or can_isg) and
+                (can_use(Hookshot) or can_use(Bow) or can_use(Slingshot) or glitch_hard_bosses)"
         }
     }
 ]

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -3,7 +3,7 @@
         "region_name": "Spirit Temple Lobby",
         "dungeon": "Spirit Temple",
         "exits": {
-            "Desert Colossus": "True",
+            "Desert Colossus From Spirit Lobby": "True",
             "Child Spirit Temple": "is_child or (is_adult and (can_mega or Hover_Boots))",
             "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or can_use(Hover_Boots) or (is_adult and can_shield)"
         }

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -13,7 +13,8 @@
             "Central Pillar from Lobby": "can_use(Hookshot) and Iron_Boots and
                 (Small_Key_Water_Temple,5)",
             "Compass Room": "can_use(Iron_Boots) and can_use(Hookshot)",
-            "Ruto Column": "can_use(Iron_Boots) or can_use(Longshot) or can_jumpslash"
+            "Ruto Column": "can_use(Iron_Boots) or can_use(Longshot) or can_jumpslash",
+            "Lake Hylia": "True"
         }
     },
     {

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -126,7 +126,7 @@
     "can_damage_boost": "not_a_glitch_damage_boost and has_explosives and can_jumpslash and (can_live_dmg(0.5) or can_use(Nayrus_Love))",
     # Blue Fire works for this, but requiring 200 rupees every time for any glitch involving cutscene items is simply too cruel.
     # Beans, big poes, both letters, and weird egg are all also cutscene items, but they can all be used up so they can't be in logic.
-	# I can't seem to add small poes or any kind of potion because it needs to be defined still. I've left it out for now but it could potentially be done.
+    # I can't seem to add small poes or any kind of potion because it needs to be defined still. I've left it out for now but it could potentially be done.
     "has_cutscene_item": "(has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
         can_use(Dins_Fire) or can_use(Farores_Wind) or can_use(Nayrus_Love) or Ocarina or has_bottle_item",
     "has_bottle_item": "(Bugs or Fish or Fairy or Milk) and Bottle",


### PR DESCRIPTION
Adds the following:
 - Updates Shadow Temple to 2.0 (Including new tricks for settingslist.json)
 - Updates Jabu to include crouch stabbing Barinade with hammer.
 - Changes map chest in well to just be "True", as this can be done with just sticks and sticks are always true in well.
 - Updates OW, DC, Forest, Fire, Water, Spirit, Ice, and GTG to make them actually work with ER. All the dungeons just needed an exit back to OW, while OW needed a bunch of little regions and for some regions to be renamed (and for me to add the missing "scene" field to SFM). (fixes issue #19)
   - Ice is **NOT** properly updated to logically work with ER yet. It currently expects child to always be able to hover and this is **not** true with ER.
 - Updates Deku to include the missing baba sticks and nuts (fixes issue #18)
 - Updates Deku to fix the Gohma logic (fixes issue #17)