### PR TITLE
110221 update

### DIFF
--- a/EntranceShuffle.py
+++ b/EntranceShuffle.py
@@ -710,7 +710,7 @@ def validate_world(world, worlds, entrance_placed, locations_to_ensure_reachable
     # Warp Songs and Overworld Spawns can also end up inside certain indoors so those need to be handled as well
     # Glitch logic needs to allow child into the carpenter tent because that's a valid entrance
     CHILD_FORBIDDEN = ['OGC Great Fairy Fountain -> Castle Grounds']
-    if (world.logic_rules == 'glitchless'):
+    if (world.settings.logic_rules == 'glitchless'):
         CHILD_FORBIDDEN.append('GV Carpenter Tent -> GV Fortress Side')
     ADULT_FORBIDDEN = ['HC Great Fairy Fountain -> Castle Grounds', 'HC Storms Grotto -> Castle Grounds']
 

--- a/Notes/glitch_logic_changes.txt
+++ b/Notes/glitch_logic_changes.txt
@@ -4,7 +4,6 @@ TO DO
 ------------------------------------
 Dungeons:
     Vanilla dungeons:
-        Forest
         Water
         Spirit
         GTG
@@ -26,8 +25,30 @@ Dungeons:
         
 UPDATED:
 ----------------------
-9/11/2021:
-    Small change to fire temple BK skip logic. It should be logically equivalent to the previous version.
+11/02/21:
+    Brought up to 2.0:
+        Vanilla Forest Temple
+            This still needs some updates, but it's now in a much better state.
+    Logic:
+        Shadow Temple: Added hammerslide to cross the statue chasm before Bongo Bongo.
+        Water Temple: Made the BK skip trick relevant. Made the hard bosses trick relevant to Morpha.
+        Spirit Temple: Made the BK skip trick relevant. No other changes
+        
+    Settings:
+        Rearranged some tricks. Now the order should be as follows:
+            Tricks which are required for other tricks to function (e.g. damage boosts, which are required for one method of bypassing the shadow door and climbing the shadow boat, among others) will be at the top.
+            General-use tricks (those with several areas of application, e.g. megaflips) will be next.
+            Tricks that are extremely similar in function (e.g. the BK skips) will be grouped together.
+            Tricks will be kept in a general ascending difficulty within these groups, except those which have a more logical grouping (e.g. the BK skips are ordered based on their dungeon order, not based on difficulty).
+        I've also updated the tags on several tricks.
+            A notable new tag is the "Component" tag, which indicates tricks which must be in logic for certain other tricks to function.
+    New glitches:
+        None
+        
+    Other changes:
+        Updated world.py to make it so that SoA can be in barren areas when not used for hints.
+        Fixed a few bugs
+    
 
 Prior to 8/7/2021:
     Brought up to 2.0 standards:
@@ -59,3 +80,16 @@ Prior to 8/7/2021:
             Adds support for the new tricks.
         settings_mapping,json
             Adds support for the new tricks.
+            
+            
+Blank for copy-paste:
+    Brought up to 2.0 standards:
+        
+    Logic:
+        
+    Settings:
+        
+    New glitches:
+        
+    Other changes:
+        

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -129,6 +129,35 @@ class Scale(Setting_Info):
         super().__init__(name, int, gui_text, 'Scale', shared, choices, default, disabled_default, disable, gui_tooltip, gui_params, cosmetic)
 
 logic_glitches = {
+    'All Uses Enabled': {
+        'name'    : 'glitch_insane',
+        'tags'    : ("General", "Component",),
+        'tooltip' : '''\
+                    When this option is enabled, all possible repeatable
+                    applications of enabled glitches are in logic.
+
+                    When disabled, only tamer applications of enabled glitches
+                    will be in logic. Check the glitched logic page on the
+                    wiki for exact details.
+            
+                    This will be a checkbox later, but I've made it a toggle
+                    for the time being, for testing purposes.
+                    '''},
+    'Damage Hovers': {
+        'name'    : 'glitch_hover',
+        'tags'    : ("General",),
+        'tooltip' : '''\
+                    By getting ISG, holding shield, and backflipping
+                    into a source of damage, you can get stuck in the
+                    air. Repeatedly doing this can allow you to gain
+                    significant height and distance.
+                    
+                    By default, only considers bomb hovers of 10 bombs or
+                    bombchus, or of stationary, predictable enemies
+                    are in logic. "All Uses Enabled" puts all bomb
+                    hovers up to 20 bombs and 50 chus into logic,
+                    as well as some tricky enemies such as Tektites.
+                    '''},
     'Putaway Ocarina Items': {
         'name'    : 'glitch_oi',
         'tags'    : ("General",),
@@ -145,7 +174,7 @@ logic_glitches = {
                     '''},
     'Equip Swap': {
         'name'    : 'glitch_equipswap',
-        'tags'    : ("General",),
+        'tags'    : ("General", "Component",),
         'tooltip' : '''\
                     By highlighting an item you want to equip, pressing
                     Z or R to switch to the next pause screen, then pressing
@@ -164,33 +193,18 @@ logic_glitches = {
                     overwrite your din's or sticks, potentially making
                     the seed unbeatable.
                     '''},
-    'Door of Time skip': {
-        'name'    : 'glitch_dot_skip',
-        'tags'    : ("General",),
+    'All Superslides': {
+        'name'    : 'glitch_slide',
+        'tags'    : ("General", "Component",),
         'tooltip' : '''\
-                    With careful movement, you can clip through the
-                    left side of the Door of Time. Child can do this
-                    completely itemlessly.
+                    Includes superslides, ESS, WESS, and HESS. While,
+                    in normal circumstances, these glitches are usually
+                    done to move quickly, they can also be used to bypass
+                    cylindrical collision (e.g. boulders) in some cases.
                     
-                    Adult requires hover boots, Giant's Knife, or
-                    Biggoron's Sword to do this, so it is expected
-                    that you will have at least one of those three
-                    items before doing this clip as EITHER age.
-                    '''},
-    'Damage Hovers': {
-        'name'    : 'glitch_hover',
-        'tags'    : ("General",),
-        'tooltip' : '''\
-                    By getting ISG, holding shield, and backflipping
-                    into a source of damage, you can get stuck in the
-                    air. Repeatedly doing this can allow you to gain
-                    significant height and distance.
-                    
-                    By default, only considers bomb hovers of 10 bombs or
-                    bombchus, or of stationary, predictable enemies
-                    are in logic. "All Uses Enabled" puts all bomb
-                    hovers up to 20 bombs and 50 chus into logic,
-                    as well as some tricky enemies such as Tektites.
+                    A-slides are never in logic due to the fact that they
+                    require a lot of consecutive frame-perfect inputs to be
+                    remotely useful.
                     '''},
     'Weirdshot and Weirdclip': {
         'name'    : 'glitch_weirdshot',
@@ -214,44 +228,8 @@ logic_glitches = {
                     weirdshot and weirdclip, it can crash if you execute
                     the glitch incorrectly.
                     '''},
-    'Forest Escape': {
-        'name'    : 'glitch_forest_escape',
-        'tags'    : ("Kokiri Forest", "Lost Woods",),
-        'tooltip' : '''\
-                    Puts all item-using methods of forest escape into
-                    logic, to bring glitched logic closed forest in line
-                    with the intent for the glitchless version. Itemless
-                    escape is only in logic with All Uses Enabled on.
-                    '''},
-    'All Superslides': {
-        'name'    : 'glitch_slide',
-        'tags'    : ("General",),
-        'tooltip' : '''\
-                    Includes superslides, ESS, WESS, and HESS. While,
-                    in normal circumstances, these glitches are usually
-                    done to move quickly, they can also be used to bypass
-                    cylindrical collision (e.g. boulders) in some cases.
-                    
-                    A-slides are never in logic due to the fact that they
-                    require a lot of consecutive frame-perfect inputs to be
-                    remotely useful.
-                    '''},
-    'All Uses Enabled': {
-        'name'    : 'glitch_insane',
-        'tags'    : ("General",),
-        'tooltip' : '''\
-                    When this option is enabled, all possible repeatable
-                    applications of enabled glitches are in logic.
-
-                    When disabled, only tamer applications of enabled glitches
-                    will be in logic. Check the glitched logic page on the
-                    wiki for exact details.
-            
-                    This will be a checkbox later, but I've made it a toggle
-                    for the time being, for testing purposes.
-                    '''},
     # UPDATE: Update this tooltip to include ledge QPA
-    'Quick Putaway': {
+     'Quick Putaway': {
         'name'    : 'glitch_qpa',
         'tags'    : ("General",),
         'tooltip' : '''\
@@ -265,6 +243,36 @@ logic_glitches = {
                     
                     The three damage values that are logically useful are
                     din's fire, ice arrow, and slingshot.
+                    
+                    For this to be in logic for adult, Equip Swap must also
+                    be in logic.
+                    '''},
+    'Door of Time skip': {
+        'name'    : 'glitch_dot_skip',
+        'tags'    : ("Temple of Time",),
+        'tooltip' : '''\
+                    With careful movement, you can clip through the
+                    left side of the Door of Time.
+                    
+                    Child can do this completely itemlessly.
+                    Adult requires hover boots, Giant's Knife, or
+                    Biggoron's Sword to do this, so it is expected
+                    that you will have at least one of those three
+                    items before doing this clip as EITHER age.
+                    Giant's Knife works even when broken.
+                    
+                    DO NOT DO DOT SKIP WITHOUT A WAY
+                    FOR ADULT TO RETURN.
+                    '''},
+    'Forest Escape': {
+        'name'    : 'glitch_forest_escape',
+        'tags'    : ("Kokiri Forest", "Lost Woods",),
+        'tooltip' : '''\
+                    Puts all item-using methods of forest escape into
+                    logic. If this is off you will always be expected to
+                    beat Deku Tree first.
+                    
+                    Itemless escape is only in logic with All Uses Enabled on.
                     '''},
     'Child Mido Skip': {
         'name'    : 'glitch_mido_skip',
@@ -382,7 +390,7 @@ logic_glitches = {
                     '''},
     'Damage Boost': {
         'name'    : 'not_a_glitch_damage_boost',
-        'tags'    : ("General",),
+        'tags'    : ("General", "Component",),
         'tooltip' : '''\
                     Not actually a glitch, but glitch-adjacent.
                     
@@ -390,8 +398,8 @@ logic_glitches = {
                     before it explodes. Shield-drop the explosive and jumpslash
                     a frame later.
                     
-                    DO NOT USE THIS TO REACH ZELDA AS CHILD EARLY, AS THIS
-                    CAN SOFTLOCK YOU!
+                    DO NOT USE THIS TO REACH ZELDA AS CHILD EARLY,
+                    AS THIS CAN SOFTLOCK YOU!
                     '''},
     'Unload Upland Zora': {
         'name'    : 'glitch_upper_zora',
@@ -413,7 +421,7 @@ logic_glitches = {
     # Please update this to include trial skip when sword shuffle is done
     'Heap Fragmentation': {
         'name'    : 'glitch_stairs',
-        'tags'    : ("General", "the Graveyard", "Ganon's Castle", "Goron City",),
+        'tags'    : ("General", "the Graveyard", "Ganon's Castle", "Goron City", "Component",),
         'tooltip' : '''\
                     By repeatedly crossing some loading triggers, you can cause
                     memory to "fragment" in such a way that certain objects cannot
@@ -427,7 +435,7 @@ logic_glitches = {
                     '''},
     'DMT GS Near Kak clip': {
         'name'    : 'glitch_dmt_gs_clip',
-        'tags'    : ("General",),
+        'tags'    : ("Death Mountain Trail",),
         'tooltip' : '''\
                     You can clip in to the alcove containing the Gold Skulltula
                     near Kakariko with a jumpslash from above. Frame-perfect,
@@ -478,7 +486,7 @@ logic_glitches = {
                     '''},
     'Forest Temple BK skip': {
         'name'    : 'glitch_bk_skip_forest',
-        'tags'    : ("General",),
+        'tags'    : ("BK Skip", "Forest Temple",),
         'tooltip' : '''\
                     UPDATE: add child vine clip
                     
@@ -491,7 +499,7 @@ logic_glitches = {
                     '''},
     'Fire Temple BK skip': {
         'name'    : 'glitch_bk_skip_fire',
-        'tags'    : ("Fire Temple",),
+        'tags'    : ("BK Skip", "Fire Temple",),
         'tooltip' : '''\
                     You can hammerslide or HESS from the hammer room to
                     fall into the loading zone for the boss room from above.
@@ -503,7 +511,7 @@ logic_glitches = {
                     '''},
     'Water Temple BK skip': {
         'name'    : 'glitch_bk_skip_water_vanilla',
-        'tags'    : ("General",),
+        'tags'    : ("BK Skip", "Water Temple",),
         'tooltip' : '''\
                     UPDATE: Add description here.
                     
@@ -512,7 +520,7 @@ logic_glitches = {
                     '''},
     'MQ Water Temple BK skip': {
         'name'    : 'glitch_bk_skip_water_mq',
-        'tags'    : ("General",),
+        'tags'    : ("BK Skip", "Water Temple",),
         'tooltip' : '''\
                     Climb on top of the right hookshot pillar, sidehop,
                     and jumpslash mid-air.
@@ -522,15 +530,16 @@ logic_glitches = {
                     '''},
     'Shadow Temple BK skip': {
         'name'    : 'glitch_bk_skip_shadow',
-        'tags'    : ("General",),
+        'tags'    : ("BK Skip", "Shadow Temple",),
         'tooltip' : '''\
-                    UPDATE: Add description here
+                    You can clip OoB in the Deadhand room and
+                    megaflip or 
                     
                     Applies to both vanilla and MQ.
                     '''},
     'Spirit Temple BK skip': {
         'name'    : 'glitch_bk_skip_spirit',
-        'tags'    : ("Spirit Temple",),
+        'tags'    : ("BK Skip", "Spirit Temple",),
         'tooltip' : '''\
                     UPDATE: Add description here
                     
@@ -574,9 +583,10 @@ logic_glitches = {
         'tags'    : ("General", "Dungeons",),
         'tooltip' : '''\
                     Puts various bosses into logic without items you would
-                    normally have. Included bosses are: King Dodongo with chus,
-                    Barinade with pots, Volvagia without tunic, Morpha without
-                    hookshot, and Bongo Bongo without projectiles.
+                    normally have. Included bosses are: Gohma without nuts,
+                    slingshot, or bow; King Dodongo with chus; Barinade with
+                    pots; Volvagia without tunic; Morpha without ookshot; and
+                    Bongo Bongo without projectiles.
                     
                     If All Uses Enabled is on and bomb hovers are in logic, then
                     this also puts Phantom Ganon without projectiles in logic.

--- a/World.py
+++ b/World.py
@@ -948,7 +948,7 @@ class World(object):
             self.settings.shuffle_scrubs == 'off' and not self.settings.shuffle_grotto_entrances):
             # nayru's love may be required to prevent forced damage
             exclude_item_list.append('Nayrus Love')
-        if self.settings.logic_grottos_without_agony and self.settings.hints != 'agony':
+        if (self.settings.logic_grottos_without_agony or self.settings.logic_rules != 'glitchless') and self.settings.hints != 'agony':
             # Stone of Agony skippable if not used for hints or grottos
             exclude_item_list.append('Stone of Agony')
         if not self.shuffle_special_interior_entrances and not self.settings.shuffle_overworld_entrances and not self.settings.warp_songs and not self.settings.spawn_positions:

--- a/data/Glitched World/Forest Temple.json
+++ b/data/Glitched World/Forest Temple.json
@@ -3,42 +3,46 @@
         "region_name": "Forest Temple Lobby",
         "dungeon": "Forest Temple",
         "locations": {
-            #If entrances are shuffled, Adult might lose access to the Kokiri forest
-            #Babas for nuts.  As this is sphere 0 for both ages, this case is covered
-            #by putting the babas here.
-            "Deku Baba Nuts": "is_adult",
-            "Deku Baba Sticks": "is_adult",
             "Forest Temple First Room Chest": "True",
-            "Forest Temple First Stalfos Chest": "can_jumpslash",
-            "Forest Temple GS First Room": "can_use(Dins_Fire) or can_use_projectile or (can_jumpslash and can_live_dmg(0.5))",
-            "Forest Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang) or can_hover"
-        },
+            # Child can use broken stick to fight the stalfos.
+            "Forest Temple First Stalfos Chest": "can_jumpslash or can_use(Megaton_Hammer)",
+            "Forest Temple GS First Room": "can_use(Dins_Fire) or can_use_projectile or (can_jumpslash and can_live_dmg(0.5)) or can_isg",
+            "Forest Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang) or can_hover",
+            "Fairy Pot": "has_bottle and (is_adult or can_child_attack or Nuts)"
+        }, 
         "exits": {
+            # Adult can ledge or acute angle clip, open for child
             "Forest Temple NW Outdoors": "True",
             "Forest Temple NE Outdoors": "can_use(Bow) or can_use(Slingshot)",
             "Forest Temple Block Push Room": "(Small_Key_Forest_Temple, 1)",
-            "Forest Temple Basement": "(Forest_Temple_Jo_and_Beth and Forest_Temple_Amy_and_Meg) or (can_use(Hover_Boots) and can_mega)",
+            "Forest Temple Basement": "(Forest_Temple_Jo_and_Beth and Forest_Temple_Amy_and_Meg) or
+                (can_use(Hover_Boots) and can_mega and glitch_forest_basement)",
+            # Hover or hoverboost
             "Forest Temple Falling Room": "can_hover or (can_use(Hover_Boots) and Bombs and can_live_dmg(0.5))",
-            "Forest Temple Boss Room": "is_adult",
+            # Child enters from the courtyard.
+            "Forest Temple Boss Room": "is_adult and glitch_bk_skip_forest",
             "SFM Forest Temple Entrance Ledge": "True"
         }
     },
+    # UPDATE: Both courtyards need a bit more looking-over, for lowgrav and for rocket chest.
     {
         "region_name": "Forest Temple NW Outdoors",
         "dungeon": "Forest Temple",
         "locations": {
+            "Deku Baba Sticks": "is_adult or Kokiri_Sword or can_isg or Boomerang",
+            "Deku Baba Nuts": "can_jumpslash or can_use(Megaton_Hammer) or
+                has_explosives or can_use(Dins_Fire)",
             "Forest Temple GS Level Island Courtyard": "
                 can_use(Longshot) or 
                 at('Forest Temple Outside Upper Ledge', can_use(Hookshot) or can_hover)"
         },
         "exits": {
             "Forest Temple Outdoors High Balconies": "
-                is_adult or 
-                (has_explosives or
-                 ((can_use(Boomerang) or Nuts or Buy_Deku_Shield) and
-                  (Sticks or Kokiri_Sword or can_use(Slingshot))))",
+                is_adult or has_explosives or
+                ((can_use(Boomerang) or Nuts or can_use(Deku_Shield)) and
+                    (Sticks or Kokiri_Sword or can_use(Slingshot)))",
             "Forest Temple Outside Upper Ledge": "can_hover or (can_use(Hover_Boots) and has_explosives and can_live_dmg(0.5))",
-            "Forest Temple Boss Room": "is_child and can_live_dmg(0.5)"
+            "Forest Temple Boss Room": "is_child and can_live_dmg(0.5) and glitch_bk_skip_forest"
         }
     },
     {
@@ -53,13 +57,10 @@
                 at('Forest Temple Falling Room', can_use(Bow) or can_use(Dins_Fire) or has_explosives or can_use(Boomerang))"
         },
         "exits": {
-            "Forest Temple Outdoors High Balconies": "can_use(Hookshot)",
-                #Longshot can grab some very high up vines to drain the well.
+            "Forest Temple Outdoors High Balconies": "can_use(Hookshot) or can_hover",
             "Forest Temple NW Outdoors": "can_use(Iron_Boots) or (Progressive_Scale, 2)",
             "Forest Temple Lobby": "True",
-            "Forest Temple Falling Room": "can_hover or
-                at('Forest Temple Outdoors High Balconies',
-                       can_use(Hover_Boots) and can_use(Scarecrow) and can_live_dmg(0.5))"
+            "Forest Temple Falling Room": "can_hover"
         }
     },
     {
@@ -71,14 +72,16 @@
         },
         "exits": {
             "Forest Temple NW Outdoors": "True",
-            "Forest Temple NE Outdoors": "True"
+            "Forest Temple NE Outdoors": "True",
+            "Forest Temple Falling Room": "can_live_dmg(0.5) and (can_mega or (can_use(Hover_Boots) and (can_use(Scarecrow))))"
         }
     },
     {
         "region_name": "Forest Temple Falling Room",
         "dungeon": "Forest Temple",
         "events": {
-            "Forest Temple Amy and Meg": "can_use(Bow)"
+            # Currently meaningless, but if we ever figure out how to activate the first two paintings for jo and beth this could mean a lot
+            "Forest Temple Amy and Meg": "can_use(Bow) or (can_hover and can_qpa)"
         },
         "locations": {
             "Forest Temple Falling Ceiling Room Chest": "True"
@@ -96,6 +99,7 @@
         },
         "exits": {
             "Forest Temple Outside Upper Ledge": "can_jumpslash",
+            # UPDATE: I really need to look at these two exits more but they're a confusing mess rn
             "Forest Temple Bow Region": "
                 (Progressive_Strength_Upgrade or (can_mega and (can_hover or Hover_Boots))) 
                 and (Small_Key_Forest_Temple, 3) and is_adult",
@@ -137,7 +141,7 @@
         },
         "exits": {
             "Forest Temple Falling Room": "
-            (Small_Key_Forest_Temple, 5) and (Bow or can_use(Dins_Fire))"
+            (Small_Key_Forest_Temple, 5) and (can_use(Bow) or can_use(Dins_Fire))"
         }
     },
     {
@@ -148,6 +152,7 @@
             "Forest Temple GS Basement": "can_use(Hookshot) or can_use(Boomerang) or can_hover"
         },
         "exits":{
+            # BK skips are handled from courtyard or main room depending on age.
             "Forest Temple Boss Room": "Boss_Key_Forest_Temple"
         }
     },
@@ -155,10 +160,12 @@
         "region_name": "Forest Temple Boss Room",
         "dungeon": "Forest Temple",
         "locations": {
-            "Forest Temple Phantom Ganon Heart": "(can_use(Hookshot) or can_use(Bow)) or 
-                (can_use(Slingshot) and (Kokiri_Sword or Sticks))",
-            "Phantom Ganon": "(can_use(Hookshot) or can_use(Bow)) or 
-                (can_use(Slingshot) and (Kokiri_Sword or Sticks))"
+            "Forest Temple Phantom Ganon Heart": "
+                (can_jumpslash or (can_use(Megaton_Hammer) and (has_bottle or can_use(Boomerang)))) and
+                (can_use(Hookshot) or can_use(Bow) or can_use(Slingshot) or (can_hover and glitch_hard_bosses and glitch_insane))",
+            "Phantom Ganon": "
+                (can_jumpslash or (can_use(Megaton_Hammer) and (has_bottle or can_use(Boomerang)))) and
+                (can_use(Hookshot) or can_use(Bow) or can_use(Slingshot) or (can_hover and glitch_hard_bosses and glitch_insane))"
         }
     }
 ]

--- a/data/Glitched World/Shadow Temple.json
+++ b/data/Glitched World/Shadow Temple.json
@@ -124,7 +124,7 @@
         },
         "exits": {
             "Shadow Boss": "
-                (has_bombchus or can_use(Distant_Scarecrow) or Bow or (can_bomb_slide and can_use(Hover_Boots)) or can_hover) and
+                (has_bombchus or can_use(Distant_Scarecrow) or Bow or (can_use(Hover_Boots) and can_shield and (can_bomb_slide or Megaton_Hammer) or can_hover)) and
                 (Small_Key_Shadow_Temple, 5) and (can_mega or can_hover or can_use(Hover_Boots)) and
                 (Boss_Key_Shadow_Temple or (is_adult and glitch_bk_skip_shadow and (can_hover or (has_explosives and can_live_dmg(0.5)))))"
         }

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -94,7 +94,7 @@
                 can_hover or
                 can_use(Hookshot)) and has_explosives",
             "Child Spirit Temple Climb": "True",
-            "Spirit Temple Boss": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives",
+            "Spirit Temple Boss": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit",
             "Early Adult Spirit Temple": "can_jumpslash or can_hover or can_use(Hookshot)"
         }
     },
@@ -156,7 +156,7 @@
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {
-            "Spirit Temple Boss": "can_use(Mirror_Shield)",
+            "Spirit Temple Boss": "can_use(Mirror_Shield) and Boss_Key_Spirit_Temple",
             "Spirit Temple Central Chamber": "can_use(Mirror_Shield) or can_use(Hookshot)"
         }
     },

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -1,178 +1,171 @@
-[    
+[
     {
-        "region_name": "Water Temple Lobby",
-        "dungeon": "Water Temple",
-        "locations": {},
+        "region_name": "Spirit Temple Lobby",
+        "dungeon": "Spirit Temple",
         "exits": {
-            "High Alcove": "is_adult or can_hover",
-            "Boss Area": "can_use(Longshot) or can_hover or (can_use(Hover_Boots) and (can_mega or Megaton_Hammer))",
-            "Dark Link Area": "(at('High Alcove', can_play(Zeldas_Lullaby)) or 
-                    (can_use(Hover_Boots) and (can_mega or Megaton_Hammer)))
-                and (Small_Key_Water_Temple, 4)",
-            "Under Entrance Block": "can_use(Hookshot) and Iron_Boots",
-            "Central Pillar from Lobby": "can_use(Hookshot) and Iron_Boots and
-                (Small_Key_Water_Temple, 4)",
-            "Compass Room": "can_use(Iron_Boots) and can_use(Hookshot)",
-            "Ruto Column": "can_use(Iron_Boots) or can_use(Longshot) or can_jumpslash",
-            "Lake Hylia": "True"
+            "Desert Colossus From Spirit Lobby": "True",
+            "Child Spirit Temple": "is_child or (is_adult and (can_mega or Hover_Boots))",
+            "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or can_use(Hover_Boots) or (is_adult and can_shield)"
         }
     },
     {
-        "region_name": "High Alcove",
-        "dungeon":  "Water Temple",
-        "locations": {},
-        "exits": {            
-            "Compass Room": "is_adult",
-            "Ruto Column": "is_adult",
-            "Under Entrance Block": "can_use(Iron_Boots) and can_use(Hookshot)",
-            "Caged Skulltula": "is_adult",
-            "Dragon Head Area": "is_adult",
-            "Boss Key Area": "is_adult and 
-                (Small_Key_Water_Temple, 4)
-                and (can_use(Longshot) or can_hover or Hover_Boots)",
-            "Boss Area": "can_play(Zeldas_Lullaby) and can_use(Longshot)",
-            "Water Temple Lobby": "can_play(Zeldas_Lullaby)"
-
-        }
-    },
-    {
-        "region_name": "Caged Skulltula",
-        "dungeon": "Water Temple",
+        "region_name": "Child Spirit Temple",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Water Temple GS Behind Gate": "(can_use(Hover_Boots) or can_hover or can_use(Hookshot)) and 
-                (can_jumpslash or has_explosives)"
-        }
-    },
-    {
-        "region_name": "Compass Room",
-        "dungeon": "Water Temple",
-        "locations": {
-            "Water Temple Compass Chest": "True"
-        }
-    },
-    {
-        "region_name": "Under Entrance Block",
-        "dungeon": "Water Temple",
-        "locations": {
-            "Water Temple Central Bow Target Chest": "True"
-        }
-    },
-    {
-        "region_name": "Ruto Column",
-        "dungeon": "Water Temple",
-        "locations": {
-            "Water Temple Map Chest": "is_adult or can_child_damage",
-            "Water Temple Cracked Wall Chest": "(can_use(Hookshot) and Iron_Boots) or
-                (can_play(Zeldas_Lullaby) and (can_use(Hookshot) or has_explosives)) ",
-            "Water Temple Torches Chest": "(here(is_child and can_use(Sticks)) or has_fire_source or can_use(Bow))
-                and can_play(Zeldas_Lullaby)"
+            "Spirit Temple Child Bridge Chest": "is_adult or
+                (
+                (can_use(Boomerang) or Slingshot or has_bombchus or can_mega) and 
+                (Sticks or has_explosives or 
+                    ( (Nuts or can_use(Boomerang)) and 
+                        (can_use(Kokiri_Sword) or Slingshot) ) ))",
+            "Spirit Temple Child Early Torches Chest": "(is_adult and has_fire_source) or 
+                (has_fire_source_with_torch and (here(is_adult) or
+                (
+                (can_use(Boomerang) or Slingshot or has_bombchus or can_mega) and 
+                (Sticks or has_explosives or 
+                    ( (Nuts or can_use(Boomerang)) and 
+                        (can_use(Kokiri_Sword) or Slingshot) ) ))))",
+            "Spirit Temple GS Metal Fence": "is_adult or
+                (
+                (can_use(Boomerang) or Slingshot or has_bombchus or can_mega) and 
+                (Sticks or has_explosives or 
+                    ( (Nuts or can_use(Boomerang)) and 
+                        (can_use(Kokiri_Sword) or Slingshot) ) ))",
+            "Nut Crate": "True"
         },
         "exits": {
-            "Central Pillar": "can_play(Zeldas_Lullaby) and 
-                ((Small_Key_Water_Temple, 5)
-                or here(is_child and can_use(Sticks)) or has_fire_source or can_use(Bow))",
-            "Boss Key Area": "(Small_Key_Water_Temple, 4) and
-                (can_use(Longshot) or can_hover or can_use(Hover_Boots)) and can_play(Zeldas_Lullaby)",
-            "Dragon Head Area": "Progressive_Strength_Upgrade and (is_adult or can_child_attack) and can_play(Zeldas_Lullaby)",
-            "Caged Skulltula": "has_explosives and can_play(Zeldas_Lullaby)",
-            "Compass Room": "can_play(Zeldas_Lullaby) and can_use(Hookshot)",
-            "Under Entrance Block": "can_play(Zeldas_Lullaby) and 
-            ( (can_use(Hookshot) and can_mega) or (can_use(Bow) and (Hover_Boots or can_use(Longshot)) 
-                and (Progressive_Strength_Upgrade or (can_use(Hookshot) and can_mega))))",
-            "High Alcove": "(can_use(Hover_Boots) or can_use(Hookshot) or (is_adult and can_mega) or can_hover)
-                and can_play(Zeldas_Lullaby)"
+            "Child Spirit Temple Climb": "(Small_Key_Spirit_Temple, 2) and
+                (is_child or ((can_mega and can_use(Longshot)) or can_use(Hover_Boots))
+                )"
         }
     },
     {
-        "region_name": "Central Pillar from Lobby",
-        "dungeon": "Water Temple",
-        "exits": {
-            "Central Pillar": "True"
-        }
-    },
-    {
-        "region_name": "Central Pillar",
-        "dungeon": "Water Temple",
+        "region_name": "Child Spirit Temple Climb",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Water Temple Central Pillar Chest": "can_use(Iron_Boots) and can_use(Hookshot) and
-                (at('Central Pillar from Lobby', True) or can_play(Zeldas_Lullaby))",
-            "Water Temple GS Central Pillar": "at('Central Pillar from Lobby', True) or
-                can_use(Longshot) or
-                at('High Alcove',
-                    can_use(Farores_Wind) and can_play(Zeldas_Lullaby)
-                    and (can_use(Hookshot) or can_use(Boomerang)))"
+            "Spirit Temple Child Climb North Chest": "at('Spirit Temple Central Chamber', True)
+                or is_child or has_projectile(adult)",
+            "Spirit Temple Child Climb East Chest": "at('Spirit Temple Central Chamber', True)
+                or is_child or has_projectile(adult)",
+            "Spirit Temple GS Sun on Floor Room": "can_use(Boomerang) or can_use(Hookshot) or
+                (can_child_damage and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or 
+                (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love)))"
         },
         "exits": {
-            "High Alcove": "(can_use(Hover_Boots) or can_use(Hookshot) or (is_adult and can_mega) or can_hover
-                or has_projectile(either))
-            and can_play(Zeldas_Lullaby)",
-            "Compass Room": "can_play(Zeldas_Lullaby) and can_use(Hookshot)"
+            "Spirit Temple Central Chamber": "has_explosives"
         }
     },
     {
-        "region_name": "Boss Key Area",
-        "dungeon": "Water Temple",
+        "region_name": "Early Adult Spirit Temple",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Water Temple Boss Key Chest": "(Small_Key_Water_Temple, 5) and
-                (is_adult or can_hover)",
-            "Water Temple GS Near Boss Key Chest": "(is_adult or can_hover) and
-                (can_use(Hookshot) or can_use(Boomerang) or can_mega)"
-        }
-    },
-    {
-        "region_name": "Dark Link Area",
-        "dungeon": "Water Temple",
-        "locations": {
-            "Water Temple Longshot Chest": "can_use(Hookshot)",
-            "Water Temple GS Falling Platform Room": "can_use(Hookshot)"
+            "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
+                (can_use(Hookshot) or can_hover) and has_projectile(either)",
+            "Spirit Temple Early Adult Right Chest": "has_projectile(either)",
+            "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 2)",
+            "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 2)",
+            "Spirit Temple GS Boulder Room": "has_projectile(either) and
+                (can_play(Song_of_Time) or can_use(Hover_Boots))"
         },
         "exits": {
-            "River": "can_play(Song_of_Time) or (can_use(Hookshot) and (Hover_Boots or (Bombs and can_live_dmg(0.5))))"
+            "Spirit Temple Central Chamber": "(Small_Key_Spirit_Temple, 2)"
         }
     },
     {
-        "region_name": "River",
-        "dungeon": "Water Temple",
+        "region_name": "Spirit Temple Central Chamber",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Water Temple GS River": "can_use(Longshot) or (Iron_Boots and can_use(Hookshot))"
+            "Spirit Temple Map Chest": "can_use(Bow) or has_fire_source_with_torch",
+            "Spirit Temple Sun Block Room Chest": "has_fire_source_with_torch or can_use(Bow)",
+            "Spirit Temple Statue Room Hand Chest": "can_play(Zeldas_Lullaby)
+                and can_jumpslash",
+            "Spirit Temple Statue Room Northeast Chest": "can_play(Zeldas_Lullaby) and can_jumpslash and
+                (can_use(Hookshot) or can_use(Hover_Boots) or can_mega)",
+            "Spirit Temple GS Hall After Sun Block Room": "can_use(Hookshot) or can_use(Boomerang) or can_hover",
+            "Spirit Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang) or can_hover
+                or can_use(Hover_Boots)"
         },
         "exits": {
-            "River Chest": "can_use(Bow) or (can_use(Longshot) and has_bottle and Iron_Boots)"
+            "Silver Gauntlets Hand": "True",
+            # access via Early Adult Spirit Temple requires 2 keys (+ jumpslash + explosives)
+            # access to Early Adult Spirit Temple guaranteed via can_jumpslash from here
+            "Spirit Temple Beyond Central Locked Door": "can_jumpslash and (
+                (Small_Key_Spirit_Temple, 2) or
+                can_hover or
+                can_use(Hookshot)) and has_explosives",
+            "Child Spirit Temple Climb": "True",
+            "Spirit Temple Boss": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit",
+            "Early Adult Spirit Temple": "can_jumpslash or can_hover or can_use(Hookshot)"
         }
     },
     {
-        "region_name": "River Chest",
-        "dungeon": "Water Temple",
+        "region_name": "Mirror Shield Hand",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Water Temple River Chest": "True"
+            "Spirit Temple Mirror Shield Chest": "True"
         },
         "exits": {
-            "Dragon Head Area": "True",
-            "River": "(can_use(Longshot) or can_use(Bow)) and can_mega"
+            "Desert Colossus": "True",
+            "Silver Gauntlets Hand": "
+                can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
+            "Spirit Temple Beyond Central Locked Door": "True"
         }
     },
     {
-        "region_name": "Dragon Head Area",
-        "dungeon": "Water Temple",
+        "region_name": "Silver Gauntlets Hand",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Water Temple Dragon Chest": "at('River Chest', is_adult) or has_bombchus or (Iron_Boots and can_use(Hookshot))"
+            "Spirit Temple Silver Gauntlets Chest": "True"
         },
         "exits": {
-            "River Chest": "can_hover"
+            "Desert Colossus": "True",
+            "Mirror Shield Hand": "can_hover or (can_use(Hover_Boots) and can_mega)",
+            "Spirit Temple Central Chamber": "(Small_Key_Spirit_Temple, 2)"
         }
     },
     {
-        "region_name": "Boss Area",
-        "dungeon": "Water Temple",
-        "events": {
-            "Water Temple Clear": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
-                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))"
-        },
+        "region_name": "Spirit Temple Outdoor Hands",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Silver Gauntlets Hand": "True",
+            "Mirror Shield Hand": "True"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Beyond Central Locked Door",
+        "dungeon": "Spirit Temple",
         "locations": {
-            "Morpha": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
-                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))",
-            "Water Temple Morpha Heart": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
-                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))"
+            "Spirit Temple Near Four Armos Chest": "can_use(Mirror_Shield)",
+            "Spirit Temple Hallway Right Invisible Chest": "True",
+            "Spirit Temple Hallway Left Invisible Chest": "True"
+        },
+        "exits": {
+            "Spirit Temple Beyond Final Locked Door": "(Small_Key_Spirit_Temple,5) and
+                (can_use(Hookshot) or has_explosives)",
+            "Mirror Shield Hand": "True",
+            "Spirit Temple Central Chamber": "has_explosives"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Beyond Final Locked Door",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Boss Key Chest": "
+                can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or (Bow and 
+                Progressive_Hookshot))",
+            "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
+        },
+        "exits": {
+            "Spirit Temple Boss": "can_use(Mirror_Shield) and Boss_Key_Spirit_Temple",
+            "Spirit Temple Central Chamber": "can_use(Mirror_Shield) or can_use(Hookshot)"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Boss",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Twinrova Heart": "True",
+            "Twinrova": "True"
         }
     }
 ]

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -165,11 +165,14 @@
         "region_name": "Boss Area",
         "dungeon": "Water Temple",
         "events": {
-            "Water Temple Clear": "can_jumpslash and (can_hover or Boss_Key_Water_Temple)"
+            "Water Temple Clear": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
+                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))"
         },
         "locations": {
-            "Morpha": "can_jumpslash and (can_hover or Boss_Key_Water_Temple)",
-            "Water Temple Morpha Heart": "can_jumpslash and (can_hover or Boss_Key_Water_Temple)"
+            "Morpha": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
+                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))",
+            "Water Temple Morpha Heart": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
+                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))"
         }
     }
 ]

--- a/data/Glitched World/Water Temple.json
+++ b/data/Glitched World/Water Temple.json
@@ -1,171 +1,178 @@
-[
+[    
     {
-        "region_name": "Spirit Temple Lobby",
-        "dungeon": "Spirit Temple",
+        "region_name": "Water Temple Lobby",
+        "dungeon": "Water Temple",
+        "locations": {},
         "exits": {
-            "Desert Colossus From Spirit Lobby": "True",
-            "Child Spirit Temple": "is_child or (is_adult and (can_mega or Hover_Boots))",
-            "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or can_use(Hover_Boots) or (is_adult and can_shield)"
+            "High Alcove": "is_adult or can_hover",
+            "Boss Area": "can_use(Longshot) or can_hover or (can_use(Hover_Boots) and (can_mega or Megaton_Hammer))",
+            "Dark Link Area": "(at('High Alcove', can_play(Zeldas_Lullaby)) or 
+                    (can_use(Hover_Boots) and (can_mega or Megaton_Hammer)))
+                and (Small_Key_Water_Temple, 4)",
+            "Under Entrance Block": "can_use(Hookshot) and Iron_Boots",
+            "Central Pillar from Lobby": "can_use(Hookshot) and Iron_Boots and
+                (Small_Key_Water_Temple, 4)",
+            "Compass Room": "can_use(Iron_Boots) and can_use(Hookshot)",
+            "Ruto Column": "can_use(Iron_Boots) or can_use(Longshot) or can_jumpslash",
+            "Lake Hylia": "True"
         }
     },
     {
-        "region_name": "Child Spirit Temple",
-        "dungeon": "Spirit Temple",
+        "region_name": "High Alcove",
+        "dungeon":  "Water Temple",
+        "locations": {},
+        "exits": {            
+            "Compass Room": "is_adult",
+            "Ruto Column": "is_adult",
+            "Under Entrance Block": "can_use(Iron_Boots) and can_use(Hookshot)",
+            "Caged Skulltula": "is_adult",
+            "Dragon Head Area": "is_adult",
+            "Boss Key Area": "is_adult and 
+                (Small_Key_Water_Temple, 4)
+                and (can_use(Longshot) or can_hover or Hover_Boots)",
+            "Boss Area": "can_play(Zeldas_Lullaby) and can_use(Longshot)",
+            "Water Temple Lobby": "can_play(Zeldas_Lullaby)"
+
+        }
+    },
+    {
+        "region_name": "Caged Skulltula",
+        "dungeon": "Water Temple",
         "locations": {
-            "Spirit Temple Child Bridge Chest": "is_adult or
-                (
-                (can_use(Boomerang) or Slingshot or has_bombchus or can_mega) and 
-                (Sticks or has_explosives or 
-                    ( (Nuts or can_use(Boomerang)) and 
-                        (can_use(Kokiri_Sword) or Slingshot) ) ))",
-            "Spirit Temple Child Early Torches Chest": "(is_adult and has_fire_source) or 
-                (has_fire_source_with_torch and (here(is_adult) or
-                (
-                (can_use(Boomerang) or Slingshot or has_bombchus or can_mega) and 
-                (Sticks or has_explosives or 
-                    ( (Nuts or can_use(Boomerang)) and 
-                        (can_use(Kokiri_Sword) or Slingshot) ) ))))",
-            "Spirit Temple GS Metal Fence": "is_adult or
-                (
-                (can_use(Boomerang) or Slingshot or has_bombchus or can_mega) and 
-                (Sticks or has_explosives or 
-                    ( (Nuts or can_use(Boomerang)) and 
-                        (can_use(Kokiri_Sword) or Slingshot) ) ))",
-            "Nut Crate": "True"
+            "Water Temple GS Behind Gate": "(can_use(Hover_Boots) or can_hover or can_use(Hookshot)) and 
+                (can_jumpslash or has_explosives)"
+        }
+    },
+    {
+        "region_name": "Compass Room",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple Compass Chest": "True"
+        }
+    },
+    {
+        "region_name": "Under Entrance Block",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple Central Bow Target Chest": "True"
+        }
+    },
+    {
+        "region_name": "Ruto Column",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple Map Chest": "is_adult or can_child_damage",
+            "Water Temple Cracked Wall Chest": "(can_use(Hookshot) and Iron_Boots) or
+                (can_play(Zeldas_Lullaby) and (can_use(Hookshot) or has_explosives)) ",
+            "Water Temple Torches Chest": "(here(is_child and can_use(Sticks)) or has_fire_source or can_use(Bow))
+                and can_play(Zeldas_Lullaby)"
         },
         "exits": {
-            "Child Spirit Temple Climb": "(Small_Key_Spirit_Temple, 2) and
-                (is_child or ((can_mega and can_use(Longshot)) or can_use(Hover_Boots))
-                )"
+            "Central Pillar": "can_play(Zeldas_Lullaby) and 
+                ((Small_Key_Water_Temple, 5)
+                or here(is_child and can_use(Sticks)) or has_fire_source or can_use(Bow))",
+            "Boss Key Area": "(Small_Key_Water_Temple, 4) and
+                (can_use(Longshot) or can_hover or can_use(Hover_Boots)) and can_play(Zeldas_Lullaby)",
+            "Dragon Head Area": "Progressive_Strength_Upgrade and (is_adult or can_child_attack) and can_play(Zeldas_Lullaby)",
+            "Caged Skulltula": "has_explosives and can_play(Zeldas_Lullaby)",
+            "Compass Room": "can_play(Zeldas_Lullaby) and can_use(Hookshot)",
+            "Under Entrance Block": "can_play(Zeldas_Lullaby) and 
+            ( (can_use(Hookshot) and can_mega) or (can_use(Bow) and (Hover_Boots or can_use(Longshot)) 
+                and (Progressive_Strength_Upgrade or (can_use(Hookshot) and can_mega))))",
+            "High Alcove": "(can_use(Hover_Boots) or can_use(Hookshot) or (is_adult and can_mega) or can_hover)
+                and can_play(Zeldas_Lullaby)"
         }
     },
     {
-        "region_name": "Child Spirit Temple Climb",
-        "dungeon": "Spirit Temple",
+        "region_name": "Central Pillar from Lobby",
+        "dungeon": "Water Temple",
+        "exits": {
+            "Central Pillar": "True"
+        }
+    },
+    {
+        "region_name": "Central Pillar",
+        "dungeon": "Water Temple",
         "locations": {
-            "Spirit Temple Child Climb North Chest": "at('Spirit Temple Central Chamber', True)
-                or is_child or has_projectile(adult)",
-            "Spirit Temple Child Climb East Chest": "at('Spirit Temple Central Chamber', True)
-                or is_child or has_projectile(adult)",
-            "Spirit Temple GS Sun on Floor Room": "can_use(Boomerang) or can_use(Hookshot) or
-                (can_child_damage and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or 
-                (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love)))"
+            "Water Temple Central Pillar Chest": "can_use(Iron_Boots) and can_use(Hookshot) and
+                (at('Central Pillar from Lobby', True) or can_play(Zeldas_Lullaby))",
+            "Water Temple GS Central Pillar": "at('Central Pillar from Lobby', True) or
+                can_use(Longshot) or
+                at('High Alcove',
+                    can_use(Farores_Wind) and can_play(Zeldas_Lullaby)
+                    and (can_use(Hookshot) or can_use(Boomerang)))"
         },
         "exits": {
-            "Spirit Temple Central Chamber": "has_explosives"
+            "High Alcove": "(can_use(Hover_Boots) or can_use(Hookshot) or (is_adult and can_mega) or can_hover
+                or has_projectile(either))
+            and can_play(Zeldas_Lullaby)",
+            "Compass Room": "can_play(Zeldas_Lullaby) and can_use(Hookshot)"
         }
     },
     {
-        "region_name": "Early Adult Spirit Temple",
-        "dungeon": "Spirit Temple",
+        "region_name": "Boss Key Area",
+        "dungeon": "Water Temple",
         "locations": {
-            "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
-                (can_use(Hookshot) or can_hover) and has_projectile(either)",
-            "Spirit Temple Early Adult Right Chest": "has_projectile(either)",
-            "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 2)",
-            "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 2)",
-            "Spirit Temple GS Boulder Room": "has_projectile(either) and
-                (can_play(Song_of_Time) or can_use(Hover_Boots))"
+            "Water Temple Boss Key Chest": "(Small_Key_Water_Temple, 5) and
+                (is_adult or can_hover)",
+            "Water Temple GS Near Boss Key Chest": "(is_adult or can_hover) and
+                (can_use(Hookshot) or can_use(Boomerang) or can_mega)"
+        }
+    },
+    {
+        "region_name": "Dark Link Area",
+        "dungeon": "Water Temple",
+        "locations": {
+            "Water Temple Longshot Chest": "can_use(Hookshot)",
+            "Water Temple GS Falling Platform Room": "can_use(Hookshot)"
         },
         "exits": {
-            "Spirit Temple Central Chamber": "(Small_Key_Spirit_Temple, 2)"
+            "River": "can_play(Song_of_Time) or (can_use(Hookshot) and (Hover_Boots or (Bombs and can_live_dmg(0.5))))"
         }
     },
     {
-        "region_name": "Spirit Temple Central Chamber",
-        "dungeon": "Spirit Temple",
+        "region_name": "River",
+        "dungeon": "Water Temple",
         "locations": {
-            "Spirit Temple Map Chest": "can_use(Bow) or has_fire_source_with_torch",
-            "Spirit Temple Sun Block Room Chest": "has_fire_source_with_torch or can_use(Bow)",
-            "Spirit Temple Statue Room Hand Chest": "can_play(Zeldas_Lullaby)
-                and can_jumpslash",
-            "Spirit Temple Statue Room Northeast Chest": "can_play(Zeldas_Lullaby) and can_jumpslash and
-                (can_use(Hookshot) or can_use(Hover_Boots) or can_mega)",
-            "Spirit Temple GS Hall After Sun Block Room": "can_use(Hookshot) or can_use(Boomerang) or can_hover",
-            "Spirit Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang) or can_hover
-                or can_use(Hover_Boots)"
+            "Water Temple GS River": "can_use(Longshot) or (Iron_Boots and can_use(Hookshot))"
         },
         "exits": {
-            "Silver Gauntlets Hand": "True",
-            # access via Early Adult Spirit Temple requires 2 keys (+ jumpslash + explosives)
-            # access to Early Adult Spirit Temple guaranteed via can_jumpslash from here
-            "Spirit Temple Beyond Central Locked Door": "can_jumpslash and (
-                (Small_Key_Spirit_Temple, 2) or
-                can_hover or
-                can_use(Hookshot)) and has_explosives",
-            "Child Spirit Temple Climb": "True",
-            "Spirit Temple Boss": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit",
-            "Early Adult Spirit Temple": "can_jumpslash or can_hover or can_use(Hookshot)"
+            "River Chest": "can_use(Bow) or (can_use(Longshot) and has_bottle and Iron_Boots)"
         }
     },
     {
-        "region_name": "Mirror Shield Hand",
-        "dungeon": "Spirit Temple",
+        "region_name": "River Chest",
+        "dungeon": "Water Temple",
         "locations": {
-            "Spirit Temple Mirror Shield Chest": "True"
+            "Water Temple River Chest": "True"
         },
         "exits": {
-            "Desert Colossus": "True",
-            "Silver Gauntlets Hand": "
-                can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
-            "Spirit Temple Beyond Central Locked Door": "True"
+            "Dragon Head Area": "True",
+            "River": "(can_use(Longshot) or can_use(Bow)) and can_mega"
         }
     },
     {
-        "region_name": "Silver Gauntlets Hand",
-        "dungeon": "Spirit Temple",
+        "region_name": "Dragon Head Area",
+        "dungeon": "Water Temple",
         "locations": {
-            "Spirit Temple Silver Gauntlets Chest": "True"
+            "Water Temple Dragon Chest": "at('River Chest', is_adult) or has_bombchus or (Iron_Boots and can_use(Hookshot))"
         },
         "exits": {
-            "Desert Colossus": "True",
-            "Mirror Shield Hand": "can_hover or (can_use(Hover_Boots) and can_mega)",
-            "Spirit Temple Central Chamber": "(Small_Key_Spirit_Temple, 2)"
+            "River Chest": "can_hover"
         }
     },
     {
-        "region_name": "Spirit Temple Outdoor Hands",
-        "dungeon": "Spirit Temple",
-        "exits": {
-            "Silver Gauntlets Hand": "True",
-            "Mirror Shield Hand": "True"
-        }
-    },
-    {
-        "region_name": "Spirit Temple Beyond Central Locked Door",
-        "dungeon": "Spirit Temple",
-        "locations": {
-            "Spirit Temple Near Four Armos Chest": "can_use(Mirror_Shield)",
-            "Spirit Temple Hallway Right Invisible Chest": "True",
-            "Spirit Temple Hallway Left Invisible Chest": "True"
+        "region_name": "Boss Area",
+        "dungeon": "Water Temple",
+        "events": {
+            "Water Temple Clear": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
+                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))"
         },
-        "exits": {
-            "Spirit Temple Beyond Final Locked Door": "(Small_Key_Spirit_Temple,5) and
-                (can_use(Hookshot) or has_explosives)",
-            "Mirror Shield Hand": "True",
-            "Spirit Temple Central Chamber": "has_explosives"
-        }
-    },
-    {
-        "region_name": "Spirit Temple Beyond Final Locked Door",
-        "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Boss Key Chest": "
-                can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or (Bow and 
-                Progressive_Hookshot))",
-            "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
-        },
-        "exits": {
-            "Spirit Temple Boss": "can_use(Mirror_Shield) and Boss_Key_Spirit_Temple",
-            "Spirit Temple Central Chamber": "can_use(Mirror_Shield) or can_use(Hookshot)"
-        }
-    },
-    {
-        "region_name": "Spirit Temple Boss",
-        "dungeon": "Spirit Temple",
-        "locations": {
-            "Spirit Temple Twinrova Heart": "True",
-            "Twinrova": "True"
+            "Morpha": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
+                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))",
+            "Water Temple Morpha Heart": "(Boss_Key_Water_Temple or (can_hover and glitch_bk_skip_water_vanilla)) and
+                (can_jumpslash or can_use(Megaton_Hammer)) and (glitch_hard_bosses or can_use(Hookshot))"
         }
     }
 ]


### PR DESCRIPTION
Updates forest for 2.0 standards.

Rearranges some tricks and updates some tags

Makes the BK skips for water and spirit relevant, in preparation for tomorrow's bingo.

Makes hard_bosses relevant for Morpha, also for the bingo.

Allows SoA to be barren when not used for hints.