### PR TITLE
Overhaul Spirit Temple and Desert Colossus logic

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -652,6 +652,19 @@ logic_glitches = {
                         With precise movement, you can then reach
                         the lower level of child spirit as adult.
                         '''},
+    'Enter Spirit Temple via Hands': {
+        'name'    : 'glitch_spirit_hands',
+        'tags'    : ("Desert Colossus", "Spirit Temple", "Dungeon Entry",),
+        'tooltip' : '''\
+                    Use hovering, a hammer recoil hoverboost from the bean, or a
+                    Hover Boots superslide from the arch to reach the overhang
+                    between the hands and then hookshot the Silver Gauntlets
+                    chest. Without Hookshot hover directly from the arch to
+                    either hand.
+
+                    All Uses Enabled adds Bombchu hovering directly to either
+                    hand without using the bean.
+                    '''},
 }
 
 logic_tricks = {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -549,9 +549,10 @@ logic_glitches = {
         'name'    : 'glitch_bk_skip_spirit',
         'tags'    : ("BK Skip", "Spirit Temple",),
         'tooltip' : '''\
-                    You can clip into the statue's head and run to the load with
-                    Hover Boots. You can also ground clip through the boss
-                    door.'
+                    You can ground clip through the boss door. You can also clip
+                    into the statue's head and run to the load with Hover Boots,
+                    which is only in logic when this is combined with Spirit
+                    Temple Statue Slide and Statue Climb.
                     
                     Applies to both vanilla and MQ.
                     '''},
@@ -670,6 +671,18 @@ logic_glitches = {
 
                     All Uses Enabled adds Bombchu hovering directly to either
                     hand without using the bean.
+                    '''},
+    'Spirit Temple Statue Slide and Statue Climb': {
+        'name'    : 'glitch_spirit_statue',
+        'tags'    : ("Spirit Temple",),
+        'tooltip' : '''\
+                    Statue slide (aka crazy dance): crossing from the child side
+                    of Spirit Temple's central chamber to the adult side by
+                    sliding along the snake on the statue's neck. Adult needs a
+                    damage boost or damage clip. Child only needs a jumpslash.
+
+                    Statue climb and head clip: Use precise jumps and
+                    jumpslashes to reach the boss door from the adult side.
                     '''},
 }
 

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -233,23 +233,27 @@ logic_glitches = {
                     the glitch incorrectly.
                     '''},
     # UPDATE: Update this tooltip to include ledge QPA
-     'Quick Putaway': {
+    'Glitched Damage': {
         'name'    : 'glitch_qpa',
         'tags'    : ("General",),
         'tooltip' : '''\
-                    By holding a stick, then pressing A to put it away and
-                    using a cutscene item (Adult trade items, bottled items,
-                    or ocarina) or nuts a frame later, then performing broken
-                    stick (Note that you will NOT actually activate broken
-                    stick if QPA is performed correctly!) your crouch stabs
-                    (as well as the initial jummpslash) will gain numerous
-                    different damage types.
-                    
-                    The three damage values that are logically useful are
-                    din's fire, ice arrow, and slingshot.
-                    
-                    For this to be in logic for adult, Equip Swap must also
-                    be in logic.
+                    Jumpslashing with nothing in hand deals numerous different
+                    damage types, and the damage is stored for power
+                    crouchstabs. This is possible by empty jumpslash or by Deku
+                    Stick quick putaway (QPA). The three damage values that are
+                    logically useful are Din's Fire, Ice Arrows, and Slingshot.
+
+                    To do empty jumpslash, walk slowly and press A to put away
+                    your weapon 2 frames before falling from Hover Boots or a
+                    ledge. Then jumpslash with that weapon on the frame before
+                    falling.
+
+                    By holding a stick, then pressing A to put it away and using
+                    a cutscene item (Adult trade items, bottled items, or
+                    ocarina) or nuts a frame later, you will get the QPA state.
+                    With QPA a jumpslash that would otherwise activate broken
+                    stick will instead deal glitched damage as the stick gets
+                    put away instantly.
                     '''},
     'Door of Time skip': {
         'name'    : 'glitch_dot_skip',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -684,15 +684,6 @@ logic_glitches = {
                     Statue climb and head clip: Use precise jumps and
                     jumpslashes to reach the boss door from the adult side.
                     '''},
-    'Iron Boots Dive': {
-        'name'    : 'glitch_ib_dive',
-        'tags'    : ("General",),
-        'tooltip' : '''\
-                    While walking into a ledge with ISG, equip iron boots and
-                    use a cutscene item simultaneously with the right timing.
-                    You will fall without taking fall damage and keep ISG even
-                    if you fall into water.
-                    '''},
 }
 
 logic_tricks = {

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -571,16 +571,23 @@ logic_glitches = {
                     instead of the object exploding on its own, the
                     chu blows the object up.
                     '''},
-    # UPDATE: Add description for EPG
     'Actor Glitch and EPG': {
         'name'    : 'glitch_actor',
         'tags'    : ("General",),
         'tooltip' : '''\
-                    By exiting a crawlspace and opening a door before
-                    the camera has returned to normal, you can load
-                    the next room while remaining in the current room,
-                    allowing you to bypass some actors, such as the
-                    water in BotW.
+                    Actor glitch: By exiting a crawlspace and opening a knobbed
+                    door before the camera has returned to normal, you can load
+                    the next room while remaining in the current room, allowing
+                    you to bypass some actors, such as the water in BotW.
+
+                    Entrance point glitch: By opening a sliding door while
+                    moving away from it at high speed, you can walk through the
+                    door but not go far enough from it for it to shut. Then you
+                    can move to set the position and angle you will respawn from
+                    if you void. When you respawn, you will walk forward from
+                    that point, even through walls. If you clip back into the
+                    previous room while the door is open, the previous room will
+                    remain loaded with some actors missing.
                     '''},
     'Bosses Without Usual Items': {
         'name'    : 'glitch_hard_bosses',

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -549,7 +549,9 @@ logic_glitches = {
         'name'    : 'glitch_bk_skip_spirit',
         'tags'    : ("BK Skip", "Spirit Temple",),
         'tooltip' : '''\
-                    UPDATE: Add description here
+                    You can clip into the statue's head and run to the load with
+                    Hover Boots. You can also ground clip through the boss
+                    door.'
                     
                     Applies to both vanilla and MQ.
                     '''},

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -684,6 +684,15 @@ logic_glitches = {
                     Statue climb and head clip: Use precise jumps and
                     jumpslashes to reach the boss door from the adult side.
                     '''},
+    'Iron Boots Dive': {
+        'name'    : 'glitch_ib_dive',
+        'tags'    : ("General",),
+        'tooltip' : '''\
+                    While walking into a ledge with ISG, equip iron boots and
+                    use a cutscene item simultaneously with the right timing.
+                    You will fall without taking fall damage and keep ISG even
+                    if you fall into water.
+                    '''},
 }
 
 logic_tricks = {

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -617,6 +617,8 @@
         "hint": "DESERT_COLOSSUS",
         "time_passes": true,
         "events": {
+            # Used in Spirit logic, checks that adult can return to the hands
+            # after either age reaches them once from here
             "Adult Spirit Hover Is Repeatable": "
                 is_adult and can_shield and
                     (bombchus_are_repeatable or (Hover_Boots and Bombs and Hookshot) or
@@ -656,6 +658,11 @@
             # Reaching either hand from here reasonably requires coming from arch or hooking silvers chest and crossing
             # from silvers to mirror. It's a *very* long hover otherwise. Logic for hovering to silvers from here
             # without hookshot would be redundant with hovering to mirror and then to silvers, so it isn't included.
+
+            # The explosive hoverboost (glitchless Spirit hover) isn't in logic due to the difficulty and the lack of a
+            # setup from the Wasteland entrance and for a slight simplification to Spirit logic (access to either hand
+            # from Colossus is equivalent). A plain hoverboots forward sidehop jumpslash is also possible, which is
+            # even harder, and AFAIK there is no documented setup.
             "Silver Gauntlets Hand Known": "glitch_spirit_hands and can_use(Hookshot) and
                 ((can_hover and (Hover_Boots or (glitch_qpa and Bombs and has_bombchus))) or
                 (here(can_plant_bean) and can_shield and Hover_Boots and ((can_bomb_slide and Bombs) or Megaton_Hammer)))",

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -615,11 +615,12 @@
         "hint": "DESERT_COLOSSUS",
         "time_passes": true,
         "locations": {
+            # Start hovering from near the top of the animated slope.
             "Colossus Freestanding PoH": "
                 (is_adult and here(can_plant_bean)) or
                 at('Mirror Shield Hand Known', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
                 at('Silver Gauntlets Hand Known', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
-                (can_hover and (can_use(Hover_Boots) or can_qpa or glitch_insane))",
+                (can_hover and glitch_insane)",
             "Colossus GS Bean Patch": "can_plant_bugs and can_child_attack",
             "Colossus GS Tree": "is_adult and (can_use(Hookshot) or can_hover or can_use(Boomerang)) and at_night",
             "Colossus GS Hill": "is_adult and at_night",
@@ -634,16 +635,16 @@
             "Spirit Temple Lobby": "True",
             # This weirdclip is hard because sand is sand and leevers are a mistake.
             "Colossus Grotto": "can_use(Silver_Gauntlets) or (can_weirdclip and glitch_insane) or (can_ledge_cancel and is_child)",
-            # Reaching either hand from here reasonably requires coming from arch or hooking silvers chest and crossing from silvers to mirror. It's a *very* long hover otherwise.
-            # Need to use a special form of QPA here so that one-time bottles aren't in logic
-            "Silver Gauntlets Hand Known": "can_hover and (can_use(Hover_Boots) or
-                (glitch_qpa and can_use(Sticks) and (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
-                    (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))))) and
-                (can_use(Hookshot) or (here(can_plant_bean) and is_adult) or (glitch_insane and has_bombchus))",
-            "Mirror Shield Hand Known": "can_hover and (can_use(Hover_Boots) or
-                (glitch_qpa and can_use(Sticks) and (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
-                    (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))))) and
-                (here(can_plant_bean and is_adult) or (glitch_insane and has_bombchus))"
+            # Reaching either hand from here reasonably requires coming from arch or hooking silvers chest and crossing
+            # from silvers to mirror. It's a *very* long hover otherwise. Logic for hovering to silvers from here
+            # without hookshot would be redundant with hovering to mirror and then to silvers, so it isn't included.
+            "Silver Gauntlets Hand Known": "can_hover and can_use(Hookshot) and
+                (Hover_Boots or (glitch_qpa and Bombs and has_bombchus))",
+            # Hovering from the arch is possible with 11 bombchu hovers or 11 QPA contortion hovers
+            # or 11 kokiri bomb hovers
+            "Mirror Shield Hand Known": "can_hover and ((here(can_plant_bean) and is_adult and
+                (has_bombchus or (glitch_qpa and has_first_person_item) or Hover_Boots or glitch_insane)) or
+                (glitch_insane and has_bombchus))"
         }
     },
     {

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -609,11 +609,21 @@
             "Haunted Wasteland": "True"
         }
     },
+    # A collection delay hookshot jump can provide access to the arch, but
+    # collection delay is never in logic due to unrepeatability
     {
         "region_name": "Desert Colossus",
         "scene": "Desert Colossus",
         "hint": "DESERT_COLOSSUS",
         "time_passes": true,
+        "events": {
+            "Adult Spirit Hover Is Repeatable": "
+                is_adult and can_shield and
+                    (bombchus_are_repeatable or (Hover_Boots and Bombs and Hookshot) or
+                    (here(can_plant_bean) and Hookshot and
+                        ((Hover_Boots and Megaton_Hammer) or
+                        (glitch_qpa and Bombs))))"
+        },
         "locations": {
             # Start hovering from near the top of the animated slope.
             # Any method from the hands is possible from either hand except a hammer hoverboost

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -617,8 +617,8 @@
         "locations": {
             "Colossus Freestanding PoH": "
                 (is_adult and here(can_plant_bean)) or
-                at('Mirror Shield Hand', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
-                at('Silver Gauntlets Hand', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
+                at('Mirror Shield Hand Known', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
+                at('Silver Gauntlets Hand Known', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
                 (can_hover and (can_use(Hover_Boots) or can_qpa or glitch_insane))",
             "Colossus GS Bean Patch": "can_plant_bugs and can_child_attack",
             "Colossus GS Tree": "is_adult and (can_use(Hookshot) or can_hover or can_use(Boomerang)) and at_night",
@@ -636,11 +636,11 @@
             "Colossus Grotto": "can_use(Silver_Gauntlets) or (can_weirdclip and glitch_insane) or (can_ledge_cancel and is_child)",
             # Reaching either hand from here reasonably requires coming from arch or hooking silvers chest and crossing from silvers to mirror. It's a *very* long hover otherwise.
             # Need to use a special form of QPA here so that one-time bottles aren't in logic
-            "Silver Gauntlets Hand": "can_hover and (can_use(Hover_Boots) or
+            "Silver Gauntlets Hand Known": "can_hover and (can_use(Hover_Boots) or
                 (glitch_qpa and can_use(Sticks) and (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
                     (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))))) and
                 (can_use(Hookshot) or (here(can_plant_bean) and is_adult) or (glitch_insane and has_bombchus))",
-            "Mirror Shield Hand": "can_hover and (can_use(Hover_Boots) or
+            "Mirror Shield Hand Known": "can_hover and (can_use(Hover_Boots) or
                 (glitch_qpa and can_use(Sticks) and (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
                     (has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))))) and
                 (here(can_plant_bean and is_adult) or (glitch_insane and has_bombchus))"

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -640,12 +640,12 @@
             # Reaching either hand from here reasonably requires coming from arch or hooking silvers chest and crossing
             # from silvers to mirror. It's a *very* long hover otherwise. Logic for hovering to silvers from here
             # without hookshot would be redundant with hovering to mirror and then to silvers, so it isn't included.
-            "Silver Gauntlets Hand Known": "can_use(Hookshot) and
+            "Silver Gauntlets Hand Known": "glitch_spirit_hands and can_use(Hookshot) and
                 ((can_hover and (Hover_Boots or (glitch_qpa and Bombs and has_bombchus))) or
                 (here(can_plant_bean) and can_shield and Hover_Boots and ((can_bomb_slide and Bombs) or Megaton_Hammer)))",
             # Hovering from the arch is possible with 11 bombchu hovers or 11 QPA contortion hovers
             # or 11 kokiri bomb hovers
-            "Mirror Shield Hand Known": "can_hover and ((here(can_plant_bean) and is_adult and
+            "Mirror Shield Hand Known": "glitch_spirit_hands and can_hover and ((here(can_plant_bean) and is_adult and
                 (has_bombchus or (glitch_qpa and has_first_person_item) or Hover_Boots or glitch_insane)) or
                 (glitch_insane and has_bombchus))"
         }

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -618,8 +618,10 @@
             # Start hovering from near the top of the animated slope.
             "Colossus Freestanding PoH": "
                 (is_adult and here(can_plant_bean)) or
-                at('Mirror Shield Hand Known', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
-                at('Silver Gauntlets Hand Known', (can_mega or (can_bomb_slide and can_use(Hover_Boots)))) or
+                at('Mirror Shield Hand Known',
+                can_mega or (can_use(Hover_Boots) and (can_bomb_slide or Megaton_Hammer or (has_explosives and can_live_dmg(0.5))))) or
+                at('Silver Gauntlets Hand Known',
+                can_mega or (can_use(Hover_Boots) and (can_bomb_slide or (Megaton_Hammer and can_shield) or (has_explosives and can_live_dmg(1.0))))) or
                 (can_hover and glitch_insane)",
             "Colossus GS Bean Patch": "can_plant_bugs and can_child_attack",
             "Colossus GS Tree": "is_adult and (can_use(Hookshot) or can_hover or can_use(Boomerang)) and at_night",
@@ -638,8 +640,9 @@
             # Reaching either hand from here reasonably requires coming from arch or hooking silvers chest and crossing
             # from silvers to mirror. It's a *very* long hover otherwise. Logic for hovering to silvers from here
             # without hookshot would be redundant with hovering to mirror and then to silvers, so it isn't included.
-            "Silver Gauntlets Hand Known": "can_hover and can_use(Hookshot) and
-                (Hover_Boots or (glitch_qpa and Bombs and has_bombchus))",
+            "Silver Gauntlets Hand Known": "can_use(Hookshot) and
+                ((can_hover and (Hover_Boots or (glitch_qpa and Bombs and has_bombchus))) or
+                (here(can_plant_bean) and can_shield and Hover_Boots and ((can_bomb_slide and Bombs) or Megaton_Hammer)))",
             # Hovering from the arch is possible with 11 bombchu hovers or 11 QPA contortion hovers
             # or 11 kokiri bomb hovers
             "Mirror Shield Hand Known": "can_hover and ((here(can_plant_bean) and is_adult and

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -616,12 +616,18 @@
         "time_passes": true,
         "locations": {
             # Start hovering from near the top of the animated slope.
+            # Any method from the hands is possible from either hand except a hammer hoverboost
+            # requires shield from Silver Gauntlets, and a damage hoverboost takes fall damage from
+            # Silver Gauntlets. Redundant possibilities are omitted.
             "Colossus Freestanding PoH": "
                 (is_adult and here(can_plant_bean)) or
+                at('Spirit Temple Adult Central Chamber Known',
+                    (Small_Key_Spirit_Temple, 4) and has_explosives and
+                    (can_mega or (can_use(Hover_Boots) and
+                    (can_bomb_slide or (Megaton_Hammer and can_shield) or (has_explosives and can_live_dmg(1.0)))))) or
                 at('Mirror Shield Hand Known',
-                can_mega or (can_use(Hover_Boots) and (can_bomb_slide or Megaton_Hammer or (has_explosives and can_live_dmg(0.5))))) or
-                at('Silver Gauntlets Hand Known',
-                can_mega or (can_use(Hover_Boots) and (can_bomb_slide or (Megaton_Hammer and can_shield) or (has_explosives and can_live_dmg(1.0))))) or
+                    can_use(Hover_Boots) and (can_bomb_slide or Megaton_Hammer or (has_explosives and can_live_dmg(0.5)))) or
+                at('Silver Gauntlets Hand Known', can_mega) or
                 (can_hover and glitch_insane)",
             "Colossus GS Bean Patch": "can_plant_bugs and can_child_attack",
             "Colossus GS Tree": "is_adult and (can_use(Hookshot) or can_hover or can_use(Boomerang)) and at_night",

--- a/data/Glitched World/Overworld.json
+++ b/data/Glitched World/Overworld.json
@@ -447,7 +447,7 @@
     {
         "region_name": "GV Upper Stream",
         "scene": "Gerudo Valley",
-        "hint": "GERUDO_VALLEY,
+        "hint": "GERUDO_VALLEY",
         "time_passes": true,
         "locations": {
             "GV Waterfall Freestanding PoH": "True",

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -17,22 +17,29 @@
             "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or
                 (glitch_strength2_blocks and (can_use(Hover_Boots) or (is_adult and can_bomb_slide))) or
                 (is_adult and has_first_person_item)",
-            "Spirit Temple Central Chamber Known": "is_adult and spirit_temple_shortcuts",
-
             # Age-known access by presence at combinations of locked doors. Access via
             # the lower doors individually is handled at their own regions. Access solely
             # via the hands is handled at Silver Gauntlets Hand Known. Each locked door
             # required is listed explicitly, even if it could be implied by other
             # requirements.
+            "Spirit Temple Central Chamber Known": "is_adult and (spirit_temple_shortcuts or
+                ((Small_Key_Spirit_Temple, 4) and
+                    (('A at Door A1' and 'A at Door C2') or
+                    ('A at Door C2' and 'A Access via Top'))) or
+                (Small_Key_Spirit_Temple, 3) and
+                    'A at Door A1' and 'A at Door C2' and 'A Access via Top')",
             "Child Spirit Temple Climb Known": "
                 ((Small_Key_Spirit_Temple, 4) and
-                    is_adult and 'A at Door C1' and 'A at Door A1') or
+                    is_adult and
+                        'A at Door C1' and 'A at Door A1') or
                 ((Small_Key_Spirit_Temple, 3) and
                     ((is_child and
                         'C at Door C1' and 'C at Door C2' and 'C at Door A2') or
                     (is_adult and
                         (('A at Door C1' and 'A at Door C2' and 'A at Door A2') or
-                        ('A at Door A1' and 'A at Door C2' and 'A at Door A2'))))) or
+                        ('A at Door C1' and 'A at Door C2' and 'A Access via Top') or
+                        ('A at Door A1' and 'A at Door C2' and 'A at Door A2') or
+                        ('A at Door A1' and 'A at Door C2' and 'A Access via Top'))))) or
                 ((Small_Key_Spirit_Temple, 2) and
                     ((is_child and
                         'C at Door C1' and 'C at Door C2' and 'C at Door A2' and 'C Access via Top') or
@@ -181,8 +188,10 @@
         "exits": {
             "Spirit Temple Adult Central Chamber Unknown": "True",
             "Spirit Temple Central Chamber Known": "True",
-            "Spirit Temple Beyond Central Locked Door Known": "(Small_Key_Spirit_Temple, 5) or
-                ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield)))",
+            "Spirit Temple Before Mirror Shield Known": "has_explosives and
+                ((Small_Key_Spirit_Temple, 5) or
+                ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield))))",
+            "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5)",
             "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
             "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit"
         }
@@ -200,7 +209,7 @@
         },
         "exits": {
             "Spirit Temple Central Chamber Unknown": "True",
-            "Spirit Temple Beyond Central Locked Door Unknown": "(Small_Key_Spirit_Temple, 4)"
+            "Spirit Temple Before Mirror Shield Unknown": "(Small_Key_Spirit_Temple, 4) and has_explosives"
         }
     },
     {
@@ -214,12 +223,15 @@
             "Silver Gauntlets Hand Unknown": "True",
             "Desert Colossus": "True",
             "Spirit Temple Lobby": "True",
-            "Mirror Shield Hand Known": "can_hover or (can_use(Hover_Boots) and can_mega) or (can_use(Hookshot) and at('Mirror Shield Hand Unknown', True))",
+            "Mirror Shield Hand Known": "can_hover or
+                (can_use(Hover_Boots) and can_shield and (can_bomb_slide or Megaton_Hammer)) or
+                (can_use(Hookshot) and at('Mirror Shield Hand Unknown', True))",
             # Assumed access to either hand if coming from Colossus
             "Spirit Temple Central Chamber Known": "is_adult and
-                ((Small_Key_Spirit_Temple, 4) or
-                ((Small_Key_Spirit_Temple, 3) and 'A Access via Top'))",
-            "Spirit Temple Central Chamber Unknown": "(Small_Key_Spirit_Temple, 2) or
+                ((Small_Key_Spirit_Temple, 5) or
+                ((Small_Key_Spirit_Temple, 4) and (has_explosives or 'A Access via Top')) or
+                ((Small_Key_Spirit_Temple, 3) and has_explosives and 'A Access via Top'))",
+            "Child Spirit Temple Climb Unknown": "(Small_Key_Spirit_Temple, 2) or
                 ((Small_Key_Spirit_Temple, 1) and 'A Access via Top')"
         }
     },
@@ -240,8 +252,8 @@
             "Mirror Shield Hand Unknown": "True",
             "Desert Colossus": "True",
             "Spirit Temple Lobby": "True",
-            "Silver Gauntlets Hand Known": "can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
-            "Spirit Temple Beyond Central Locked Door Known": "True"
+            "Silver Gauntlets Hand Known": "can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_bomb_slide)",
+            "Spirit Temple Before Mirror Shield Known": "True"
         }
     },
     {
@@ -252,38 +264,38 @@
         },
         "exits": {
             "Silver Gauntlets Hand Unknown": "child_can_hover and (adult_can_hover or Hookshot)",
-            "Spirit Temple Beyond Central Locked Door Unknown": "True"
+            "Spirit Temple Before Mirror Shield Unknown": "True"
         }
     },
     {
-        "region_name": "Spirit Temple Beyond Central Locked Door Known",
+        "region_name": "Spirit Temple Before Mirror Shield Known",
         "dungeon": "Spirit Temple",
         "events": {
+            # Child already has explosives if coming from Colossus
             "C at Door A2": "is_child",
-            "A at Door A2": "is_adult",
+            "A at Door A2": "is_adult and has_explosives",
             "C Access via Top": "is_child and here(can_use(Mirror_Shield) or spirit_temple_shortcuts)",
             # When weirdshotting, use a jumpslash recoil to land on the floor
             # instead of the statue so you don't take fall damage.
             "A Access via Top": "can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))"
         },
         "locations": {
-            "Spirit Temple Near Four Armos Chest": "has_explosives and can_use(Mirror_Shield)"
+            "Spirit Temple Near Four Armos Chest": "can_use(Mirror_Shield)"
         },
         "exits": {
-            "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5) and
-                (can_use(Hookshot) or has_explosives)",
-            "Mirror Shield Hand Known": "has_explosives"
+            "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5)",
+            "Mirror Shield Hand Known": "True"
         }
     },
     {
-        "region_name": "Spirit Temple Beyond Central Locked Door Unknown",
+        "region_name": "Spirit Temple Before Mirror Shield Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Hallway Right Invisible Chest": "has_explosives",
-            "Spirit Temple Hallway Left Invisible Chest": "has_explosives"
+            "Spirit Temple Hallway Right Invisible Chest": "True",
+            "Spirit Temple Hallway Left Invisible Chest": "True"
         },
         "exits": {
-            "Mirror Shield Hand Unknown": "has_explosives"
+            "Mirror Shield Hand Unknown": "True"
         }
     },
     {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -162,8 +162,11 @@
         "dungeon": "Spirit Temple",
         "exits": {
             "Spirit Temple Central Chamber Unknown": "True",
-            "Spirit Temple Adult Central Chamber Known": "can_use(Hookshot) or can_use(Hover_Boots) or can_hover or
-                (is_adult and has_explosives and can_live_dmg(0.5)) or (is_child and (can_jumpslash or can_use(Megaton_Hammer)))",
+            "Spirit Temple Adult Central Chamber Known": "
+                can_use(Hookshot) or can_use(Hover_Boots) or can_hover or
+                (glitch_spirit_statue and
+                    ((is_adult and has_explosives and can_live_dmg(0.5)) or
+                    (is_child and (can_jumpslash or can_use(Megaton_Hammer)))))",
             # Ground clip into and out of the Knuckle room
             "Silver Gauntlets Hand Known": "(Small_Key_Spirit_Temple, 5) or
                 ((Small_Key_Spirit_Temple, 4) and (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots)))) or
@@ -191,8 +194,12 @@
         },
         "exits": {
             "Spirit Temple Adult Central Chamber Unknown": "
-                (Kokiri_Sword or Sticks or (child_can_equipswap and Megaton_Hammer)) and
-                (Hookshot or Hover_Boots or (has_explosives and can_live_dmg(0.5)) or adult_can_hover or
+                (child_can_hover or
+                (glitch_spirit_statue and
+                    (Kokiri_Sword or Sticks or (child_can_equipswap and Megaton_Hammer)))) and
+
+                (Hookshot or Hover_Boots or adult_can_hover or
+                (glitch_spirit_statue and has_explosives and can_live_dmg(0.5)) or
                 not spirit_temple_shortcuts)",
             "Child Spirit Temple Climb Unknown": "True",
             "Silver Gauntlets Hand Unknown": "child_can_hover and adult_can_hover and
@@ -210,17 +217,7 @@
                 ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield))))",
             "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5)",
             "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
-            # Use some precise jumps to climb the statue and clip into the head.
-            "Spirit Temple Boss Door": "
-                Boss_Key_Spirit_Temple or
-                (glitch_bk_skip_spirit and
-                    (can_use(Hover_Boots) or
-                    (can_hover and
-                        ((can_live_dmg(0.5) and shuffle_bosses == 'off') or
-                        (has_bombchus and
-                            ((is_adult and has_2h_sword) or
-                            can_use(Sticks) or can_use(Megaton_Hammer))))) or
-                    (can_mega and can_use(Iron_Boots))))",
+            "Spirit Temple Before Boss": "glitch_spirit_statue or (spirit_temple_shortcuts and can_use(Hookshot))",
             "Desert Colossus": "(Small_Key_Spirit_Temple, 4) and has_explosives"
         }
     },
@@ -333,6 +330,26 @@
             "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or
                 (here(can_use(Bow) or can_qpa or (glitch_qpa and can_isg)) and can_use(Hookshot)))",
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
+        },
+        "exits": {
+            "Spirit Temple Before Boss": "here(can_use(Mirror_Shield) or spirit_temple_shortcuts) and
+                (can_use(Hookshot) or can_hover)"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Before Boss",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Spirit Temple Boss Door": "
+                Boss_Key_Spirit_Temple or
+                (glitch_bk_skip_spirit and
+                    ((glitch_spirit_statue and can_use(Hover_Boots)) or
+                    (can_hover and
+                        ((can_live_dmg(0.5) and shuffle_bosses == 'off') or
+                        (has_bombchus and
+                            ((is_adult and has_2h_sword) or
+                            can_use(Sticks) or can_use(Megaton_Hammer))))) or
+                    (can_mega and can_use(Iron_Boots))))"
         }
     }
 ]

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -3,12 +3,54 @@
     # Location rules in unknown-age regions check that either both ages have the necessary
     # items or one age is at the known-age variant with the necessary items.
 
+    # There are some ways to reach the central chamber that are possible to lose access
+    # to:
+    # A. In-logic methods out of logic using consumable bombchus, consumable bottle
+    #    items, or a losable shield
+    # B. An inherently unrepeatable method using in-logic or togglable glitches
+    #     * Use hoverboots to climb the 1st silver block, hover to the shortcut, and
+    #       ground clip to reach the door
+    # C. Glitches that are never in logic
+    #     * Token delay hookshot jump to reach the hands.
+    #     * Action swap ground jump from a hover to climb the 1st silver block
+    # D. A very hard method that is never in logic using consumable bombchus or a losable
+    #    shield
+    #     * Hovering from OoB floor in the lobby to the shortcut
+    # E. Unrepeatable access to the temple or Colossus
+
+    # This logic is designed to prevent softlocks from A. If you lose the bombchus,
+    # bottle item, or shield you initially use to reach a locked door, you may be
+    # expected to return by using the same toggleable glitches with different items.
+    # With the protections for A, softlocks from E should be rare and only possible in
+    # ER.
+
     # Any number of keys can be required to get to the regions blocked by locked doors.
     # The requirements for one-key access include a choice between Mirror Shield to lower
     # the top elevator and longshot weirdshot to clip through it.
     {
         "region_name": "Spirit Temple Lobby",
         "dungeon": "Spirit Temple",
+        "events": {
+            # Checks that you can return to any locked door you open that blocks Central
+            # Chamber. If this is the Child Spirit door, you will blocked by the
+            # explosive requirement at Child Climb.
+
+            # Logical access to one door + the Any Door Is Repeatable event
+            # is enough for logical age-unknown access to Child Climb. Can also have age-
+            # unknown access without checking for this event with logical access to
+            # multiple doors and enough keys to unlock one. Age-unknown access is omitted
+            # in exit rules when the requirements are the same as age-known, such as
+            # anything requiring all 5 keys.
+            "Any Door Is Repeatable": "(is_child or 'A at Door C1' or
+                (explosives_are_repeatable and (Hylian_Shield or Mirror_Shield) and can_live_dmg(1.5))) and
+
+                (Silver_Gauntlets or (glitch_strength2_blocks and Hover_Boots) or has_first_person_item or
+                (Bombs and can_live_dmg(0.5)) or (explosives_are_repeatable and (Hylian_Shield or Mirror_Shield))) and
+
+                ('Adult Spirit Hover Is Repeatable' or 'C at Door C2' or
+                (Deku_Shield and (Sticks or Kokiri_Sword or (Megaton_Hammer and child_can_equipswap)) and
+                (Hylian_Shield or Mirror_Shield) and bombchus_are_repeatable))"
+        },
         "exits": {
             "Desert Colossus From Spirit Lobby": "True",
             # Clip with a weirdclip, armos hess, bomb push, or TSC
@@ -22,9 +64,9 @@
                 has_first_person_item)",
             # Age-known access by presence at combinations of locked doors. Access via
             # the lower doors individually is handled at their own regions. Access solely
-            # via the hands is handled at Silver Gauntlets Hand Known. Each locked door
-            # required is listed explicitly, even if it could be implied by other
-            # requirements.
+            # via the hands is at Silver Gauntlets Hand Known. Age-unknown access by
+            # combinations is at Early Child Spirit Temple. Each locked door required is
+            # listed explicitly, even if it could be implied by other requirements.
             "Spirit Temple Central Chamber Known": "is_adult and (spirit_temple_shortcuts or
                 ((Small_Key_Spirit_Temple, 4) and
                     (('A at Door A1' and 'A at Door C2') or
@@ -47,10 +89,10 @@
                     ((is_child and
                         'C at Door C1' and 'C at Door C2' and 'C at Door A2' and 'C Access via Top') or
                     (is_adult and
-                        'A at Door C1' and 'A at Door A1' and at('Desert Colossus', is_adult and can_isg)))) or
+                        'A at Door C1' and 'A at Door A1' and 'Adult Spirit Hover Is Repeatable'))) or
                 ((Small_Key_Spirit_Temple, 1) and
                     is_adult and
-                        (('A at Door C1' and 'A at Door A1' and at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot)))) or
+                        (('A at Door C1' and 'A at Door A1' and 'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))) or
                         ('A at Door C1' and 'A at Door C2' and 'A at Door A2' and 'A Access via Top')))"
         }
     },
@@ -83,13 +125,20 @@
                 here(
                     can_use(Boomerang) or can_use(Slingshot) or can_use(Bow) or can_use(Hookshot) or has_bombchus or
                     can_mega or can_use(Hover_Boots))",
-            "Child Spirit Temple Climb Known": "(Small_Key_Spirit_Temple, 5) and (is_child or 'A at Door C1')",
+            "Child Spirit Temple Climb Known": "(Small_Key_Spirit_Temple, 5) and
+                (is_child or 'A at Door C1')",
             "Child Spirit Temple Climb Unknown": "(is_child or 'A at Door C1') and
-                ((Small_Key_Spirit_Temple, 2) or
-                ((Small_Key_Spirit_Temple, 1) and
-                    (at('Desert Colossus',
-                        can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))) or
-                    spirit_temple_shortcuts)))",
+                (((Small_Key_Spirit_Temple, 4) and
+                    ('A at Door A1' or 'A at Door C2')) or
+                ((Small_Key_Spirit_Temple, 3) and
+                    (('A at Door C2' and 'A at Door A2') or
+                    ('A at Door C2' and 'A Access via Top'))) or
+                ('Any Door Is Repeatable' and
+                    ((Small_Key_Spirit_Temple, 2) or
+                    ((Small_Key_Spirit_Temple, 1) and
+                        (('Adult Spirit Hover Is Repeatable' and
+                            (Mirror_Shield or (glitch_weirdshot and has_explosives and Longshot))) or
+                        spirit_temple_shortcuts)))))",
             "Spirit Temple Adult Central Chamber Unknown": "
                 ((is_child and
                     ((glitch_spirit_statue and (can_jumpslash or can_use(Megaton_Hammer))) or can_hover)) or
@@ -97,10 +146,12 @@
 
                 has_explosives and
 
-                ((Small_Key_Spirit_Temple, 2) or
-                ((Small_Key_Spirit_Temple, 1) and not spirit_temple_shortcuts and
-                    at('Desert Colossus',
-                        can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot)))))"
+                (((Small_Key_Spirit_Temple, 4) and 'A at Door A1') or
+                ('Any Door Is Repeatable' and
+                    ((Small_Key_Spirit_Temple, 2) or
+                    ((Small_Key_Spirit_Temple, 1) and not spirit_temple_shortcuts and
+                        'Adult Spirit Hover Is Repeatable' and
+                        (Mirror_Shield or (glitch_weirdshot and Longshot))))))"
         }
     },
     {
@@ -130,14 +181,22 @@
         },
         "exits": {
             "Spirit Temple Adult Central Chamber Known": "(Small_Key_Spirit_Temple, 5)",
-            "Child Spirit Temple Climb Unknown": "
-                (Small_Key_Spirit_Temple, 2) or
+            "Child Spirit Temple Climb Unknown": "'Any Door Is Repeatable' and
+                ((Small_Key_Spirit_Temple, 2) or
                 ((Small_Key_Spirit_Temple, 1) and
-                    at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))))",
-            "Spirit Temple Adult Central Chamber Unknown": "
-                (Small_Key_Spirit_Temple, 3) or
+                    'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))))",
+            "Spirit Temple Central Chamber Unknown": "'Any Door Is Repeatable' and explosives_are_repeatable and
+                ((Small_Key_Spirit_Temple, 3) or
                 ((Small_Key_Spirit_Temple, 2) and
-                    at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))))"
+                    'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))))",
+            "Spirit Temple Adult Central Chamber Unknown": "
+                'Any Door Is Repeatable' and explosives_are_repeatable and
+                (Sticks or Kokiri_Sword or (child_can_equipswap and Megaton_Hammer)) and
+                (glitch_spirit_statue or Deku_Shield) and
+
+                ((Small_Key_Spirit_Temple, 3) or
+                ((Small_Key_Spirit_Temple, 2) and
+                    'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))))"
         }
     },
     {
@@ -147,6 +206,7 @@
             "Nut Crate": "(Small_Key_Spirit_Temple, 5)"
         },
         "exits": {
+            "Child Spirit Temple Climb Unknown": "True",
             "Early Child Spirit Temple": "(Small_Key_Spirit_Temple, 5) and can_weirdshot and can_use(Hookshot)",
             "Spirit Temple Central Chamber Known": "has_explosives"
         }
@@ -261,7 +321,9 @@
         },
         "exits": {
             "Spirit Temple Central Chamber Unknown": "True",
-            "Spirit Temple Before Mirror Shield Unknown": "(Small_Key_Spirit_Temple, 4) and has_explosives"
+            "Spirit Temple Before Mirror Shield Unknown": "(Small_Key_Spirit_Temple, 4) and has_explosives and
+                Deku_Shield and (Sticks or Kokiri_Sword or (Megaton_Hammer and child_can_equipswap)) and
+                (Hylian_Shield or Mirror_Shield)"
         }
     },
     {
@@ -283,9 +345,19 @@
                 ((Small_Key_Spirit_Temple, 5) or
                 ((Small_Key_Spirit_Temple, 4) and (has_explosives or 'A Access via Top')) or
                 ((Small_Key_Spirit_Temple, 3) and has_explosives and 'A Access via Top'))",
-            "Child Spirit Temple Climb Unknown": "(Small_Key_Spirit_Temple, 2) or
-                ((Small_Key_Spirit_Temple, 1) and 'A Access via Top')",
+            "Child Spirit Temple Climb Unknown": "'Any Door Is Repeatable' and
+                ((Small_Key_Spirit_Temple, 2) or
+                ((Small_Key_Spirit_Temple, 1) and 'A Access via Top'))",
+            "Spirit Temple Central Chamber Unknown": "(can_use(Hookshot) or can_hover) and
+                'Any Door Is Repeatable' and explosives_are_repeatable and
+
+                ((Small_Key_Spirit_Temple, 3) or
+                ((Small_Key_Spirit_Temple, 2) and 'A Access via Top'))",
             "Spirit Temple Adult Central Chamber Unknown": "(can_use(Hookshot) or can_hover) and
+                'Any Door Is Repeatable' and explosives_are_repeatable and
+                (Sticks or Kokiri_Sword or (child_can_equipswap and Megaton_Hammer)) and
+                (glitch_spirit_statue or Deku_Shield) and
+
                 ((Small_Key_Spirit_Temple, 3) or
                 ((Small_Key_Spirit_Temple, 2) and 'A Access via Top'))"
         }

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -235,7 +235,7 @@
                     has_projectile(adult) or can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love) or
                     ((Hylian_Shield or Mirror_Shield) and (
                         glitch_hover or
-                        (glitch_ib_dive and Iron_Boots and
+                        (Iron_Boots and
                             (has_adult_trade_item or can_use(Farores_Wind) or has_bottle_item)))))) or
 
                 at('Child Spirit Temple Climb Known', can_use_projectile or

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -94,7 +94,7 @@
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Child Bridge Chest": "True",
-            "Spirit Temple Child Early Torches Chest": "has_fire_source_with_torch",
+            "Spirit Temple Child Early Torches Chest": "has_fire_source_with_torch or (glitch_qpa and can_isg)",
             "Spirit Temple GS Metal Fence": "True"
         }
     },
@@ -166,10 +166,15 @@
         "region_name": "Spirit Temple Central Chamber Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Map Chest": "can_use(Dins_Fire) or ((Bow or adult_can_equipswap) and Sticks) or
-                at('Spirit Temple Central Chamber Known', can_use(Bow) or can_use(Sticks))",
-            "Spirit Temple Sun Block Room Chest": "can_use(Dins_Fire) or ((Bow or adult_can_equipswap) and Sticks) or
-                at('Spirit Temple Central Chamber Known', can_use(Bow) or can_use(Sticks))",
+            "Spirit Temple Map Chest": "can_use(Dins_Fire) or
+                (glitch_qpa and (Kokiri_Sword or (child_can_equipswap and Megaton_Hammer))) or
+                ((Bow or glitch_qpa or adult_can_equipswap) and Sticks) or
+                at('Spirit Temple Central Chamber Known',
+                can_use(Bow) or can_use(Sticks) or (glitch_qpa and is_adult))",
+            "Spirit Temple Sun Block Room Chest": "can_use(Dins_Fire) or
+                ((Sticks or (glitch_qpa and (Kokiri_Sword or (child_can_equipswap and Megaton_Hammer)) and Deku_Shield)) and
+                (Bow or (adult_can_equipswap and Sticks) or (glitch_qpa and (Hylian_Shield or Mirror_Shield)))) or
+                at('Spirit Temple Central Chamber Known', can_use(Bow) or can_use(Sticks) or (glitch_qpa and can_isg))",
             "Spirit Temple GS Hall After Sun Block Room": "(adult_can_equipswap and Boomerang) or
                 ((Boomerang or child_can_hover) and (Hookshot or adult_can_hover)) or
                 at('Spirit Temple Central Chamber Known', can_use(Hookshot) or can_use(Boomerang) or can_hover)",
@@ -302,8 +307,8 @@
         "region_name": "Spirit Temple Top",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and
-                (can_live_dmg(1.0) or (is_adult and Bow and Hookshot))",
+            "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or
+                (here(can_use(Bow) or can_qpa or (glitch_qpa and can_isg)) and can_use(Hookshot)))",
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -1,4 +1,11 @@
 [
+    # Many regions in Spirit Temple are split between unknown- and known-age variants.
+    # Location rules in unknown-age regions check that either both ages have the necessary
+    # items or one age is at the known-age variant with the necessary items.
+
+    # Any number of keys can be required to get to the regions blocked by locked doors.
+    # The requirements for one-key access include a choice between Mirror Shield to lower
+    # the top elevator and longshot weirdshot to clip through it.
     {
         "region_name": "Spirit Temple Lobby",
         "dungeon": "Spirit Temple",
@@ -10,15 +17,45 @@
             "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or
                 (glitch_strength2_blocks and (can_use(Hover_Boots) or (is_adult and can_bomb_slide))) or
                 (is_adult and has_first_person_item)",
-            "Spirit Temple Central Chamber": "is_adult and spirit_temple_shortcuts"
+            "Spirit Temple Central Chamber Known": "is_adult and spirit_temple_shortcuts",
+
+            # Age-known access by presence at combinations of locked doors. Access via
+            # the lower doors individually is handled at their own regions. Access solely
+            # via the hands is handled at Silver Gauntlets Hand Known. Each locked door
+            # required is listed explicitly, even if it could be implied by other
+            # requirements.
+            "Child Spirit Temple Climb Known": "
+                ((Small_Key_Spirit_Temple, 4) and
+                    is_adult and 'A at Door C1' and 'A at Door A1') or
+                ((Small_Key_Spirit_Temple, 3) and
+                    ((is_child and
+                        'C at Door C1' and 'C at Door C2' and 'C at Door A2') or
+                    (is_adult and
+                        (('A at Door C1' and 'A at Door C2' and 'A at Door A2') or
+                        ('A at Door A1' and 'A at Door C2' and 'A at Door A2'))))) or
+                ((Small_Key_Spirit_Temple, 2) and
+                    ((is_child and
+                        'C at Door C1' and 'C at Door C2' and 'C at Door A2' and 'C Access via Top') or
+                    (is_adult and
+                        'A at Door C1' and 'A at Door A1' and at('Desert Colossus', is_adult and can_isg)))) or
+                ((Small_Key_Spirit_Temple, 1) and
+                    is_adult and
+                        (('A at Door C1' and 'A at Door A1' and at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot)))) or
+                        ('A at Door C1' and 'A at Door C2' and 'A at Door A2' and 'A Access via Top')))"
         }
     },
-    # UPDATE: I've done what I can for the logic, but I simply can't parse the key logic well enough to tell if there's softlocks.
-    # Softlock potential will need to be evaluated either by someone better at this nonsense than me, or by playtesting.
-    # 2.0's going to go through a few months of beta testing before I PR it anyway, so we have time to catch any bugs.+
     {
         "region_name": "Early Child Spirit Temple",
         "dungeon": "Spirit Temple",
+        "events": {
+            "C at Door C1": "is_child",
+            "A at Door C1": "
+                is_adult and
+                    ((can_weirdshot and Longshot) or
+                    (glitch_actor and Hookshot and
+                        ((can_shield and Hover_Boots and can_live_dmg(1.0)) or
+                        (has_explosives and can_live_dmg(1.5)))))"
+        },
         "locations": {
             # Duplicated in Child Spirit Temple Climb Known with alternate requirements
             "Nut Crate": "
@@ -36,13 +73,13 @@
                 here(
                     can_use(Boomerang) or can_use(Slingshot) or can_use(Bow) or can_use(Hookshot) or has_bombchus or
                     can_mega or can_use(Hover_Boots))",
-            "Child Spirit Temple Climb": "
-                (Small_Key_Spirit_Temple, 2) and
-                    (is_child or
-                    (can_weirdshot and Longshot) or
-                    (glitch_actor and Hookshot and
-                        ((can_shield and Hover_Boots and can_live_dmg(1.0)) or
-                        (has_explosives and can_live_dmg(1.5)))))"
+            "Child Spirit Temple Climb Known": "(Small_Key_Spirit_Temple, 5) and (is_child or 'A at Door C1')",
+            "Child Spirit Temple Climb Unknown": "(is_child or 'A at Door C1') and
+                ((Small_Key_Spirit_Temple, 2) or
+                ((Small_Key_Spirit_Temple, 1) and
+                    (at('Desert Colossus',
+                        can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))) or
+                    spirit_temple_shortcuts)))"
         }
     },
     {
@@ -55,117 +92,210 @@
         }
     },
     {
-        "region_name": "Child Spirit Temple Climb",
+        "region_name": "Child Spirit Temple Climb Known",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Child Climb North Chest": "at('Spirit Temple Central Chamber', True)
-                or is_child or has_projectile(adult)",
-            "Spirit Temple Child Climb East Chest": "at('Spirit Temple Central Chamber', True)
-                or is_child or has_projectile(adult)",
-            "Spirit Temple GS Sun on Floor Room": "can_use(Boomerang) or can_use(Hookshot) or
-                (can_child_damage and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or 
-                (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love)))",
             "Nut Crate": "(Small_Key_Spirit_Temple, 5)"
         },
         "exits": {
-            "Spirit Temple Central Chamber": "has_explosives"
+            "Spirit Temple Central Chamber Known": "has_explosives"
+        }
+    },
+    {
+        "region_name": "Child Spirit Temple Climb Unknown",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Child Climb North Chest": "has_projectile(both) or
+                at('Child Spirit Temple Climb Known', can_use_projectile)",
+            "Spirit Temple Child Climb East Chest": "has_projectile(both) or
+                at('Child Spirit Temple Climb Known', can_use_projectile)",
+            "Spirit Temple GS Sun on Floor Room": "(adult_can_equipswap and Boomerang) or
+                ((Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or (child_can_equipswap and Megaton_Hammer)) and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or
+                at('Child Spirit Temple Climb Known',
+                can_use(Boomerang) or can_use(Hookshot) or (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))))"
+        },
+        "exits": {
+            "Spirit Temple Central Chamber Unknown": "has_explosives"
         }
     },
     {
         "region_name": "Early Adult Spirit Temple",
         "dungeon": "Spirit Temple",
+        "events": {
+            "A at Door A1": "is_adult"
+        },
         "locations": {
             "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
-                (can_use(Hookshot) or can_hover) and has_projectile(either)",
-            "Spirit Temple Early Adult Right Chest": "has_projectile(either)",
-            "Spirit Temple First Mirror Left Chest": "(Small_Key_Spirit_Temple, 2)",
-            "Spirit Temple First Mirror Right Chest": "(Small_Key_Spirit_Temple, 2)",
-            "Spirit Temple GS Boulder Room": "has_projectile(either) and
+                (can_use(Hookshot) or can_hover)",
+            # Both ages can jumpslash the silver rupee without a damage boost.
+            # Child is already expected to jumpslash to get to adult side.
+            "Spirit Temple Early Adult Right Chest": "can_use_projectile",
+            "Spirit Temple GS Boulder Room": "here(can_use_projectile) and
                 (can_play(Song_of_Time) or can_use(Hover_Boots))"
         },
         "exits": {
-            "Spirit Temple Central Chamber": "(Small_Key_Spirit_Temple, 2)"
+            "Spirit Temple Adult Central Chamber Known": "(Small_Key_Spirit_Temple, 5)",
+            "Child Spirit Temple Climb Unknown": "
+                (Small_Key_Spirit_Temple, 2) or
+                ((Small_Key_Spirit_Temple, 1) and
+                    at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))))",
+            "Spirit Temple Central Chamber Unknown": "
+                (Small_Key_Spirit_Temple, 3) or
+                ((Small_Key_Spirit_Temple, 2) and
+                    at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))))"
         }
     },
     {
-        "region_name": "Spirit Temple Central Chamber",
+        "region_name": "Spirit Temple Adult Central Chamber Known",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Spirit Temple Adult Central Chamber Unknown": "True",
+            "Spirit Temple Central Chamber Known": "True",
+            "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit",
+            "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
+            "Spirit Temple Beyond Central Locked Door Known": "(Small_Key_Spirit_Temple, 5) or
+                ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield)))"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Adult Central Chamber Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Map Chest": "can_use(Bow) or has_fire_source_with_torch",
-            "Spirit Temple Sun Block Room Chest": "has_fire_source_with_torch or can_use(Bow)",
-            "Spirit Temple Statue Room Hand Chest": "can_play(Zeldas_Lullaby)
-                and can_jumpslash",
-            "Spirit Temple Statue Room Northeast Chest": "can_play(Zeldas_Lullaby) and can_jumpslash and
-                (can_use(Hookshot) or can_use(Hover_Boots) or can_mega)",
-            "Spirit Temple GS Hall After Sun Block Room": "can_use(Hookshot) or can_use(Boomerang) or can_hover",
-            "Spirit Temple GS Lobby": "can_use(Hookshot) or can_use(Boomerang) or can_hover
-                or can_use(Hover_Boots)"
+            "Spirit Temple First Mirror Left Chest": "True",
+            "Spirit Temple First Mirror Right Chest": "True",
+            "Spirit Temple Statue Room Hand Chest": "can_play(Zeldas_Lullaby)",
+            "Spirit Temple Statue Room Northeast Chest": "can_play(Zeldas_Lullaby) and
+                ((glitch_megaflip and has_explosives and Deku_Shield) or
+                at('Spirit Temple Adult Central Chamber Known', is_adult))"
         },
         "exits": {
-            "Silver Gauntlets Hand": "True",
-            # access via Early Adult Spirit Temple requires 2 keys (+ jumpslash + explosives)
-            # access to Early Adult Spirit Temple guaranteed via can_jumpslash from here
-            "Spirit Temple Beyond Central Locked Door": "can_jumpslash and has_explosives and
-                ((Small_Key_Spirit_Temple, 2) or can_hover or can_use(Hookshot))",
-            "Child Spirit Temple Climb": "True",
-            "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit",
-            "Early Adult Spirit Temple": "can_jumpslash or can_hover or can_use(Hookshot)"
+            "Spirit Temple Central Chamber Unknown": "True",
+            "Spirit Temple Beyond Central Locked Door Unknown": "(Small_Key_Spirit_Temple, 4)"
         }
     },
     {
-        "region_name": "Mirror Shield Hand",
+        "region_name": "Spirit Temple Central Chamber Known",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Spirit Temple Central Chamber Unknown": "True",
+            "Spirit Temple Adult Central Chamber Known": "can_jumpslash",
+            "Silver Gauntlets Hand Known": "(Small_Key_Spirit_Temple, 5) or
+                ((Small_Key_Spirit_Temple, 4) and (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots))))"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Central Chamber Unknown",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Map Chest": "can_use(Dins_Fire) or ((Bow or adult_can_equipswap) and Sticks) or
+                at('Spirit Temple Central Chamber Known', can_use(Bow) or can_use(Sticks))",
+            "Spirit Temple Sun Block Room Chest": "can_use(Dins_Fire) or ((Bow or adult_can_equipswap) and Sticks) or
+                at('Spirit Temple Central Chamber Known', can_use(Bow) or can_use(Sticks))",
+            "Spirit Temple GS Hall After Sun Block Room": "(adult_can_equipswap and Boomerang) or
+                ((Boomerang or child_can_hover) and (Hookshot or adult_can_hover)) or
+                at('Spirit Temple Central Chamber Known', can_use(Hookshot) or can_use(Boomerang) or can_hover)",
+            "Spirit Temple GS Lobby": "Boomerang or child_can_hover or
+                at('Spirit Temple Central Chamber Known', is_adult)"
+        },
+        "exits": {
+            "Spirit Temple Adult Central Chamber Unknown": "Kokiri_Sword or Sticks or
+                (child_can_equipswap and Megaton_Hammer)",
+            "Child Spirit Temple Climb Unknown": "True"
+        }
+    },
+    {
+        "region_name": "Mirror Shield Hand Known",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Mirror Shield Hand Unknown": "True",
+            "Desert Colossus": "True",
+            "Spirit Temple Lobby": "True",
+            "Silver Gauntlets Hand Known": "can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
+            "Spirit Temple Beyond Central Locked Door Known": "True"
+        }
+    },
+    {
+        "region_name": "Mirror Shield Hand Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Mirror Shield Chest": "True"
         },
         "exits": {
-            "Desert Colossus": "True",
-            "Spirit Temple Lobby": "True",
-            "Silver Gauntlets Hand": "
-                can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
-            "Spirit Temple Beyond Central Locked Door": "True"
+            "Silver Gauntlets Hand Unknown": "child_can_hover and (adult_can_hover or Hookshot)",
+            "Spirit Temple Beyond Central Locked Door Unknown": "True"
         }
     },
     {
-        "region_name": "Silver Gauntlets Hand",
+        "region_name": "Silver Gauntlets Hand Known",
+        "dungeon": "Spirit Temple",
+        "events": {
+            "C at Door C2": "is_child",
+            "A at Door C2": "is_adult"
+        },
+        "exits": {
+            "Silver Gauntlets Hand Unknown": "True",
+            "Desert Colossus": "True",
+            "Spirit Temple Lobby": "True",
+            "Mirror Shield Hand Known": "can_hover or (can_use(Hover_Boots) and can_mega) or (can_use(Hookshot) and at('Mirror Shield Hand Unknown', True))",
+            # Assumed access to either hand if coming from Colossus
+            "Spirit Temple Central Chamber Known": "is_adult and
+                ((Small_Key_Spirit_Temple, 4) or
+                ((Small_Key_Spirit_Temple, 3) and 'A Access via Top'))",
+            "Spirit Temple Central Chamber Unknown": "(Small_Key_Spirit_Temple, 2) or
+                ((Small_Key_Spirit_Temple, 1) and 'A Access via Top')"
+        }
+    },
+    {
+        "region_name": "Silver Gauntlets Hand Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Silver Gauntlets Chest": "True"
         },
         "exits": {
-            "Desert Colossus": "True",
-            "Spirit Temple Lobby": "True",
-            "Mirror Shield Hand": "can_hover or (can_use(Hover_Boots) and can_mega)",
-            "Spirit Temple Central Chamber": "(Small_Key_Spirit_Temple, 2)"
+            "Mirror Shield Hand Unknown": "child_can_hover and adult_can_hover"
         }
     },
     {
-        "region_name": "Spirit Temple Beyond Central Locked Door",
+        "region_name": "Spirit Temple Beyond Central Locked Door Known",
         "dungeon": "Spirit Temple",
+        "events": {
+            "C at Door A2": "is_child",
+            "A at Door A2": "is_adult",
+            "C Access via Top": "is_child and here(can_use(Mirror_Shield) or spirit_temple_shortcuts)",
+            # When weirdshotting, use a jumpslash recoil to land on the floor
+            # instead of the statue so you don't take fall damage.
+            "A Access via Top": "can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))"
+        },
         "locations": {
-            "Spirit Temple Near Four Armos Chest": "can_use(Mirror_Shield)",
-            "Spirit Temple Hallway Right Invisible Chest": "True",
-            "Spirit Temple Hallway Left Invisible Chest": "True"
+            "Spirit Temple Near Four Armos Chest": "has_explosives and can_use(Mirror_Shield)"
         },
         "exits": {
-            "Spirit Temple Top": "(Small_Key_Spirit_Temple,5) and
+            "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5) and
                 (can_use(Hookshot) or has_explosives)",
-            "Mirror Shield Hand": "True",
-            "Spirit Temple Central Chamber": "has_explosives"
+            "Mirror Shield Hand Known": "has_explosives"
+        }
+    },
+    {
+        "region_name": "Spirit Temple Beyond Central Locked Door Unknown",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Hallway Right Invisible Chest": "has_explosives",
+            "Spirit Temple Hallway Left Invisible Chest": "has_explosives"
+        },
+        "exits": {
+            "Mirror Shield Hand Unknown": "has_explosives"
         }
     },
     {
         "region_name": "Spirit Temple Top",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Boss Key Chest": "
-                can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or (Bow and 
-                Progressive_Hookshot))",
+            "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and
+                (can_live_dmg(1.0) or (is_adult and Bow and Hookshot))",
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {
-            "Spirit Temple Boss Door": "can_use(Mirror_Shield) and Boss_Key_Spirit_Temple",
-            "Spirit Temple Central Chamber": "can_use(Mirror_Shield) or can_use(Hookshot)"
+            "Spirit Temple Boss Door": "can_use(Mirror_Shield) and Boss_Key_Spirit_Temple"
         }
     }
 ]

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -47,9 +47,11 @@
                 (Silver_Gauntlets or (glitch_strength2_blocks and Hover_Boots) or has_first_person_item or
                 (Bombs and can_live_dmg(0.5)) or (explosives_are_repeatable and (Hylian_Shield or Mirror_Shield))) and
 
-                ('Adult Spirit Hover Is Repeatable' or 'C at Door C2' or
+                'Spirit Hover Is Repeatable'",
+            # The Adult Spirit Hover Is Repeatable event is defined at Colossus
+            "Spirit Hover Is Repeatable": "'Adult Spirit Hover Is Repeatable' or 'C at Door C2' or
                 (Deku_Shield and (Sticks or Kokiri_Sword or (Megaton_Hammer and child_can_equipswap)) and
-                (Hylian_Shield or Mirror_Shield) and bombchus_are_repeatable))"
+                (Hylian_Shield or Mirror_Shield) and bombchus_are_repeatable)"
         },
         "exits": {
             "Desert Colossus From Spirit Lobby": "True",
@@ -255,8 +257,14 @@
                     ((is_adult and has_explosives and can_live_dmg(0.5)) or
                     (is_child and (can_jumpslash or can_use(Megaton_Hammer)))))",
             # Ground clip into and out of the Knuckle room
-            "Silver Gauntlets Hand Known": "(Small_Key_Spirit_Temple, 5) or
-                ((Small_Key_Spirit_Temple, 4) and (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots)))) or
+            "Silver Gauntlets Hand Known": "
+                (Small_Key_Spirit_Temple, 5) or
+                ((Small_Key_Spirit_Temple, 4) and
+                    has_explosives and
+                    (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots)) or can_hover)) or
+                ((Small_Key_Spirit_Temple, 3) and
+                    'Adult Spirit Hover Is Repeatable' and is_adult and has_explosives and
+                    (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots)) or can_hover)) or
                 (can_hover and (can_live_dmg(0.5) or glitch_insane))"
         }
     },
@@ -289,8 +297,12 @@
                 (glitch_spirit_statue and has_explosives and can_live_dmg(0.5)) or
                 not spirit_temple_shortcuts)",
             "Child Spirit Temple Climb Unknown": "True",
-            "Silver Gauntlets Hand Unknown": "child_can_hover and adult_can_hover and
-                (can_live_dmg(0.5) or glitch_insane)"
+            "Silver Gauntlets Hand Unknown": "
+                ((Small_Key_Spirit_Temple, 4) and
+                    child_can_hover and (adult_can_hover or Hookshot)) or
+                ((Small_Key_Spirit_Temple, 3) and
+                    'Spirit Hover Is Repeatable' and child_can_hover and (adult_can_hover or Hookshot)) or
+                (child_can_hover and adult_can_hover and (can_live_dmg(0.5) or glitch_insane))"
         }
     },
     {
@@ -301,7 +313,11 @@
             "Spirit Temple Central Chamber Known": "True",
             "Spirit Temple Before Mirror Shield Known": "has_explosives and
                 ((Small_Key_Spirit_Temple, 5) or
-                ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield))))",
+                ((Small_Key_Spirit_Temple, 4) and
+                    (can_hover or (is_adult and can_shield))) or
+                ((Small_Key_Spirit_Temple, 3) and
+                    'Adult Spirit Hover Is Repeatable' and is_adult and
+                    (can_hover or (can_shield and Hover_Boots and (Megaton_Hammer or can_bomb_slide)))))",
             "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5)",
             "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
             "Spirit Temple Before Boss": "glitch_spirit_statue or (spirit_temple_shortcuts and can_use(Hookshot))",
@@ -321,9 +337,13 @@
         },
         "exits": {
             "Spirit Temple Central Chamber Unknown": "True",
-            "Spirit Temple Before Mirror Shield Unknown": "(Small_Key_Spirit_Temple, 4) and has_explosives and
-                Deku_Shield and (Sticks or Kokiri_Sword or (Megaton_Hammer and child_can_equipswap)) and
-                (Hylian_Shield or Mirror_Shield)"
+            "Spirit Temple Before Mirror Shield Unknown": "
+                ((Small_Key_Spirit_Temple, 4) and
+                    has_explosives and
+                    Deku_Shield and (Sticks or Kokiri_Sword or (Megaton_Hammer and child_can_equipswap)) and
+                    (Hylian_Shield or Mirror_Shield)) or
+                ((Small_Key_Spirit_Temple, 3) and
+                    'Spirit Hover Is Repeatable' and child_can_hover and adult_can_hover)"
         }
     },
     {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -148,14 +148,14 @@
             "Spirit Temple Hallway Left Invisible Chest": "True"
         },
         "exits": {
-            "Spirit Temple Beyond Final Locked Door": "(Small_Key_Spirit_Temple,5) and
+            "Spirit Temple Top": "(Small_Key_Spirit_Temple,5) and
                 (can_use(Hookshot) or has_explosives)",
             "Mirror Shield Hand": "True",
             "Spirit Temple Central Chamber": "has_explosives"
         }
     },
     {
-        "region_name": "Spirit Temple Beyond Final Locked Door",
+        "region_name": "Spirit Temple Top",
         "dungeon": "Spirit Temple",
         "locations": {
             "Spirit Temple Boss Key Chest": "

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -11,12 +11,15 @@
         "dungeon": "Spirit Temple",
         "exits": {
             "Desert Colossus From Spirit Lobby": "True",
+            # Clip with a weirdclip, armos hess, bomb push, or TSC
             "Early Child Spirit Temple": "is_child or (glitch_weirdshot and can_mega) or
                 (glitch_slide and can_shield and can_use(Hover_Boots)) or
+                (Bombs and (can_shield or can_live_dmg(0.5)) and (Hover_Boots or can_mega)) or
                 (glitch_spirit_crawlspace and has_first_person_item)",
-            "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or
-                (glitch_strength2_blocks and (can_use(Hover_Boots) or (is_adult and can_bomb_slide))) or
-                (is_adult and has_first_person_item)",
+            "Early Adult Spirit Temple": "is_adult and (Silver_Gauntlets or
+                (glitch_strength2_blocks and (Hover_Boots or can_bomb_slide)) or
+                (Bombs and (can_shield or can_live_dmg(0.5))) or
+                has_first_person_item)",
             # Age-known access by presence at combinations of locked doors. Access via
             # the lower doors individually is handled at their own regions. Access solely
             # via the hands is handled at Silver Gauntlets Hand Known. Each locked door
@@ -106,12 +109,13 @@
         },
         "locations": {
             "Spirit Temple Compass Chest": "can_play(Zeldas_Lullaby) and
-                (can_use(Hookshot) or can_hover)",
+                (can_use(Hookshot) or can_use(Hover_Boots) or can_hover)",
             # Both ages can jumpslash the silver rupee without a damage boost.
             # Child is already expected to jumpslash to get to adult side.
             "Spirit Temple Early Adult Right Chest": "can_use_projectile",
-            "Spirit Temple GS Boulder Room": "here(can_use_projectile) and
-                (can_play(Song_of_Time) or can_use(Hover_Boots))"
+            # Clip to the room behind it to hookshot it
+            "Spirit Temple GS Boulder Room": "can_use_projectile and
+                (can_play(Song_of_Time) or can_use(Hookshot) or can_use(Boomerang))"
         },
         "exits": {
             "Spirit Temple Adult Central Chamber Known": "(Small_Key_Spirit_Temple, 5)",
@@ -132,6 +136,7 @@
             "Nut Crate": "(Small_Key_Spirit_Temple, 5)"
         },
         "exits": {
+            "Early Child Spirit Temple": "(Small_Key_Spirit_Temple, 5) and can_weirdshot and can_use(Hookshot)",
             "Spirit Temple Central Chamber Known": "has_explosives"
         }
     },
@@ -181,7 +186,7 @@
             "Spirit Temple GS Hall After Sun Block Room": "(adult_can_equipswap and Boomerang) or
                 ((Boomerang or child_can_hover) and (Hookshot or adult_can_hover)) or
                 at('Spirit Temple Central Chamber Known', can_use(Hookshot) or can_use(Boomerang) or can_hover)",
-            "Spirit Temple GS Lobby": "Boomerang or child_can_hover or
+            "Spirit Temple GS Lobby": "Boomerang or (glitch_megaflip and has_explosives and Deku_Shield) or
                 at('Spirit Temple Central Chamber Known', is_adult)"
         },
         "exits": {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -157,7 +157,8 @@
         "dungeon": "Spirit Temple",
         "exits": {
             "Spirit Temple Central Chamber Unknown": "True",
-            "Spirit Temple Adult Central Chamber Known": "can_jumpslash",
+            "Spirit Temple Adult Central Chamber Known": "can_use(Hookshot) or can_use(Hover_Boots) or can_hover or
+                (is_adult and has_explosives and can_live_dmg(0.5)) or (is_child and (can_jumpslash or can_use(Megaton_Hammer)))",
             "Silver Gauntlets Hand Known": "(Small_Key_Spirit_Temple, 5) or
                 ((Small_Key_Spirit_Temple, 4) and (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots))))"
         }
@@ -182,8 +183,10 @@
                 at('Spirit Temple Central Chamber Known', is_adult)"
         },
         "exits": {
-            "Spirit Temple Adult Central Chamber Unknown": "Kokiri_Sword or Sticks or
-                (child_can_equipswap and Megaton_Hammer)",
+            "Spirit Temple Adult Central Chamber Unknown": "
+                (Kokiri_Sword or Sticks or (child_can_equipswap and Megaton_Hammer)) and
+                (Hookshot or Hover_Boots or (has_explosives and can_live_dmg(0.5)) or adult_can_hover or
+                not spirit_temple_shortcuts)",
             "Child Spirit Temple Climb Unknown": "True"
         }
     },

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -94,7 +94,7 @@
                         'A at Door C1' and 'A at Door A1' and 'Adult Spirit Hover Is Repeatable'))) or
                 ((Small_Key_Spirit_Temple, 1) and
                     is_adult and
-                        (('A at Door C1' and 'A at Door A1' and 'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))) or
+                        (('A at Door C1' and 'A at Door A1' and 'Adult Spirit Hover Is Repeatable' and ((Mirror_Shield and has_explosives) or (can_weirdshot and Longshot))) or
                         ('A at Door C1' and 'A at Door C2' and 'A at Door A2' and 'A Access via Top')))"
         }
     },
@@ -139,7 +139,7 @@
                     ((Small_Key_Spirit_Temple, 2) or
                     ((Small_Key_Spirit_Temple, 1) and
                         (('Adult Spirit Hover Is Repeatable' and
-                            (Mirror_Shield or (glitch_weirdshot and has_explosives and Longshot))) or
+                            ((Mirror_Shield and has_explosives) or (glitch_weirdshot and has_explosives and Longshot))) or
                         spirit_temple_shortcuts)))))",
             "Spirit Temple Adult Central Chamber Unknown": "
                 ((is_child and
@@ -186,11 +186,11 @@
             "Child Spirit Temple Climb Unknown": "'Any Door Is Repeatable' and
                 ((Small_Key_Spirit_Temple, 2) or
                 ((Small_Key_Spirit_Temple, 1) and
-                    'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))))",
+                    'Adult Spirit Hover Is Repeatable' and ((Mirror_Shield and has_explosives) or (can_weirdshot and Longshot))))",
             "Spirit Temple Central Chamber Unknown": "'Any Door Is Repeatable' and explosives_are_repeatable and
                 ((Small_Key_Spirit_Temple, 3) or
                 ((Small_Key_Spirit_Temple, 2) and
-                    'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))))",
+                    'Adult Spirit Hover Is Repeatable' and ((Mirror_Shield and has_explosives) or (can_weirdshot and Longshot))))",
             "Spirit Temple Adult Central Chamber Unknown": "
                 'Any Door Is Repeatable' and explosives_are_repeatable and
                 (Sticks or Kokiri_Sword or (child_can_equipswap and Megaton_Hammer)) and
@@ -198,7 +198,7 @@
 
                 ((Small_Key_Spirit_Temple, 3) or
                 ((Small_Key_Spirit_Temple, 2) and
-                    'Adult Spirit Hover Is Repeatable' and (Mirror_Shield or (can_weirdshot and Longshot))))"
+                    'Adult Spirit Hover Is Repeatable' and ((Mirror_Shield and has_explosives) or (can_weirdshot and Longshot))))"
         }
     },
     {
@@ -421,10 +421,10 @@
             # Child already has explosives if coming from Colossus
             "C at Door A2": "is_child",
             "A at Door A2": "is_adult and has_explosives",
-            "C Access via Top": "is_child and here(can_use(Mirror_Shield) or spirit_temple_shortcuts)",
+            "C Access via Top": "is_child and (here(can_use(Mirror_Shield) and has_explosives) or spirit_temple_shortcuts)",
             # When weirdshotting, use a jumpslash recoil to land on the floor
             # instead of the statue so you don't take fall damage.
-            "A Access via Top": "can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))"
+            "A Access via Top": "(can_use(Mirror_Shield) and has_explosives) or (can_weirdshot and can_use(Longshot))"
         },
         "locations": {
             "Spirit Temple Near Four Armos Chest": "can_use(Mirror_Shield)"
@@ -463,7 +463,7 @@
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {
-            "Spirit Temple Before Boss": "here(can_use(Mirror_Shield) or spirit_temple_shortcuts) and
+            "Spirit Temple Before Boss": "(here(can_use(Mirror_Shield) and has_explosives) or spirit_temple_shortcuts) and
                 (can_use(Hookshot) or can_hover)"
         }
     },

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -89,7 +89,18 @@
                 ((Small_Key_Spirit_Temple, 1) and
                     (at('Desert Colossus',
                         can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))) or
-                    spirit_temple_shortcuts)))"
+                    spirit_temple_shortcuts)))",
+            "Spirit Temple Adult Central Chamber Unknown": "
+                ((is_child and
+                    ((glitch_spirit_statue and (can_jumpslash or can_use(Megaton_Hammer))) or can_hover)) or
+                'A at Door C1') and
+
+                has_explosives and
+
+                ((Small_Key_Spirit_Temple, 2) or
+                ((Small_Key_Spirit_Temple, 1) and not spirit_temple_shortcuts and
+                    at('Desert Colossus',
+                        can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot)))))"
         }
     },
     {
@@ -123,7 +134,7 @@
                 (Small_Key_Spirit_Temple, 2) or
                 ((Small_Key_Spirit_Temple, 1) and
                     at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))))",
-            "Spirit Temple Central Chamber Unknown": "
+            "Spirit Temple Adult Central Chamber Unknown": "
                 (Small_Key_Spirit_Temple, 3) or
                 ((Small_Key_Spirit_Temple, 2) and
                     at('Desert Colossus', can_use(Mirror_Shield) or (can_weirdshot and can_use(Longshot))))"
@@ -257,7 +268,10 @@
                 ((Small_Key_Spirit_Temple, 4) and (has_explosives or 'A Access via Top')) or
                 ((Small_Key_Spirit_Temple, 3) and has_explosives and 'A Access via Top'))",
             "Child Spirit Temple Climb Unknown": "(Small_Key_Spirit_Temple, 2) or
-                ((Small_Key_Spirit_Temple, 1) and 'A Access via Top')"
+                ((Small_Key_Spirit_Temple, 1) and 'A Access via Top')",
+            "Spirit Temple Adult Central Chamber Unknown": "(can_use(Hookshot) or can_hover) and
+                ((Small_Key_Spirit_Temple, 3) or
+                ((Small_Key_Spirit_Temple, 2) and 'A Access via Top'))"
         }
     },
     {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -159,8 +159,10 @@
             "Spirit Temple Central Chamber Unknown": "True",
             "Spirit Temple Adult Central Chamber Known": "can_use(Hookshot) or can_use(Hover_Boots) or can_hover or
                 (is_adult and has_explosives and can_live_dmg(0.5)) or (is_child and (can_jumpslash or can_use(Megaton_Hammer)))",
+            # Ground clip into and out of the Knuckle room
             "Silver Gauntlets Hand Known": "(Small_Key_Spirit_Temple, 5) or
-                ((Small_Key_Spirit_Temple, 4) and (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots))))"
+                ((Small_Key_Spirit_Temple, 4) and (can_use(Hookshot) or (can_bomb_slide and can_use(Hover_Boots)))) or
+                (can_hover and (can_live_dmg(0.5) or glitch_insane))"
         }
     },
     {
@@ -187,7 +189,9 @@
                 (Kokiri_Sword or Sticks or (child_can_equipswap and Megaton_Hammer)) and
                 (Hookshot or Hover_Boots or (has_explosives and can_live_dmg(0.5)) or adult_can_hover or
                 not spirit_temple_shortcuts)",
-            "Child Spirit Temple Climb Unknown": "True"
+            "Child Spirit Temple Climb Unknown": "True",
+            "Silver Gauntlets Hand Unknown": "child_can_hover and adult_can_hover and
+                (can_live_dmg(0.5) or glitch_insane)"
         }
     },
     {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -159,10 +159,26 @@
                 at('Child Spirit Temple Climb Known', can_use_projectile)",
             "Spirit Temple Child Climb East Chest": "has_projectile(both) or
                 at('Child Spirit Temple Climb Known', can_use_projectile)",
-            "Spirit Temple GS Sun on Floor Room": "(adult_can_equipswap and Boomerang) or
-                ((Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or (child_can_equipswap and Megaton_Hammer)) and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or
-                at('Child Spirit Temple Climb Known',
-                can_use(Boomerang) or can_use(Hookshot) or (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))))"
+            # Use projectiles or Din's or jumpslash it (take fall damage) or hover off of it
+            # or hit it with an Iron Boots ISG dive (use something other than ocarina for the cutscene item)
+            "Spirit Temple GS Sun on Floor Room": "
+                can_use(Dins_Fire) or
+                ((Sticks or Kokiri_Sword) and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or
+
+                ((
+                    has_projectile(child) or
+                    (glitch_hover and Deku_Shield and
+                        (Sticks or Kokiri_Sword or (child_can_equipswap and Megaton_Hammer)))) and
+                (
+                    has_projectile(adult) or can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love) or
+                    ((Hylian_Shield or Mirror_Shield) and (
+                        glitch_hover or
+                        (glitch_ib_dive and Iron_Boots and
+                            (has_adult_trade_item or can_use(Farores_Wind) or has_bottle_item)))))) or
+
+                at('Child Spirit Temple Climb Known', can_use_projectile or
+                    (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or can_enemy_hover or
+                    (can_ib_dive and (has_adult_trade_item or can_use(Farores_Wind) or has_bottle_item)))"
         },
         "exits": {
             "Spirit Temple Central Chamber Unknown": "has_explosives"
@@ -341,8 +357,17 @@
         "region_name": "Spirit Temple Top",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or
-                (here(can_use(Bow) or can_qpa or (glitch_qpa and can_isg)) and can_use(Hookshot)))",
+            # With roll invincibility, you can open the flaming chest and not
+            # take damage until after you receive the item. Out of kindness,
+            # that's not in logic in OHKO without a way to avoid the game over.
+            # Out of cruelty however, you can be expected to spawn the platform
+            # as child and hookshot to it as adult.
+            "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and
+                (can_live_dmg(0.25) or Fairy or
+                (can_use(Hookshot) and
+                    (can_use(Nayrus_Love) or
+                    here(can_use(Bow) or can_use(Slingshot) or can_qpa or (glitch_qpa and can_isg)))) or
+                can_hover)",
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
         },
         "exits": {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -92,33 +92,6 @@
         }
     },
     {
-        "region_name": "Child Spirit Temple Climb Known",
-        "dungeon": "Spirit Temple",
-        "locations": {
-            "Nut Crate": "(Small_Key_Spirit_Temple, 5)"
-        },
-        "exits": {
-            "Spirit Temple Central Chamber Known": "has_explosives"
-        }
-    },
-    {
-        "region_name": "Child Spirit Temple Climb Unknown",
-        "dungeon": "Spirit Temple",
-        "locations": {
-            "Spirit Temple Child Climb North Chest": "has_projectile(both) or
-                at('Child Spirit Temple Climb Known', can_use_projectile)",
-            "Spirit Temple Child Climb East Chest": "has_projectile(both) or
-                at('Child Spirit Temple Climb Known', can_use_projectile)",
-            "Spirit Temple GS Sun on Floor Room": "(adult_can_equipswap and Boomerang) or
-                ((Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or (child_can_equipswap and Megaton_Hammer)) and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or
-                at('Child Spirit Temple Climb Known',
-                can_use(Boomerang) or can_use(Hookshot) or (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))))"
-        },
-        "exits": {
-            "Spirit Temple Central Chamber Unknown": "has_explosives"
-        }
-    },
-    {
         "region_name": "Early Adult Spirit Temple",
         "dungeon": "Spirit Temple",
         "events": {
@@ -146,31 +119,30 @@
         }
     },
     {
-        "region_name": "Spirit Temple Adult Central Chamber Known",
+        "region_name": "Child Spirit Temple Climb Known",
         "dungeon": "Spirit Temple",
+        "locations": {
+            "Nut Crate": "(Small_Key_Spirit_Temple, 5)"
+        },
         "exits": {
-            "Spirit Temple Adult Central Chamber Unknown": "True",
-            "Spirit Temple Central Chamber Known": "True",
-            "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit",
-            "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
-            "Spirit Temple Beyond Central Locked Door Known": "(Small_Key_Spirit_Temple, 5) or
-                ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield)))"
+            "Spirit Temple Central Chamber Known": "has_explosives"
         }
     },
     {
-        "region_name": "Spirit Temple Adult Central Chamber Unknown",
+        "region_name": "Child Spirit Temple Climb Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple First Mirror Left Chest": "True",
-            "Spirit Temple First Mirror Right Chest": "True",
-            "Spirit Temple Statue Room Hand Chest": "can_play(Zeldas_Lullaby)",
-            "Spirit Temple Statue Room Northeast Chest": "can_play(Zeldas_Lullaby) and
-                ((glitch_megaflip and has_explosives and Deku_Shield) or
-                at('Spirit Temple Adult Central Chamber Known', is_adult))"
+            "Spirit Temple Child Climb North Chest": "has_projectile(both) or
+                at('Child Spirit Temple Climb Known', can_use_projectile)",
+            "Spirit Temple Child Climb East Chest": "has_projectile(both) or
+                at('Child Spirit Temple Climb Known', can_use_projectile)",
+            "Spirit Temple GS Sun on Floor Room": "(adult_can_equipswap and Boomerang) or
+                ((Slingshot or Sticks or Kokiri_Sword or has_explosives or can_use(Dins_Fire) or (child_can_equipswap and Megaton_Hammer)) and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or
+                at('Child Spirit Temple Climb Known',
+                can_use(Boomerang) or can_use(Hookshot) or (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))))"
         },
         "exits": {
-            "Spirit Temple Central Chamber Unknown": "True",
-            "Spirit Temple Beyond Central Locked Door Unknown": "(Small_Key_Spirit_Temple, 4)"
+            "Spirit Temple Central Chamber Unknown": "has_explosives"
         }
     },
     {
@@ -204,25 +176,31 @@
         }
     },
     {
-        "region_name": "Mirror Shield Hand Known",
+        "region_name": "Spirit Temple Adult Central Chamber Known",
         "dungeon": "Spirit Temple",
         "exits": {
-            "Mirror Shield Hand Unknown": "True",
-            "Desert Colossus": "True",
-            "Spirit Temple Lobby": "True",
-            "Silver Gauntlets Hand Known": "can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
-            "Spirit Temple Beyond Central Locked Door Known": "True"
+            "Spirit Temple Adult Central Chamber Unknown": "True",
+            "Spirit Temple Central Chamber Known": "True",
+            "Spirit Temple Beyond Central Locked Door Known": "(Small_Key_Spirit_Temple, 5) or
+                ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield)))",
+            "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
+            "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit"
         }
     },
     {
-        "region_name": "Mirror Shield Hand Unknown",
+        "region_name": "Spirit Temple Adult Central Chamber Unknown",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Mirror Shield Chest": "True"
+            "Spirit Temple First Mirror Left Chest": "True",
+            "Spirit Temple First Mirror Right Chest": "True",
+            "Spirit Temple Statue Room Hand Chest": "can_play(Zeldas_Lullaby)",
+            "Spirit Temple Statue Room Northeast Chest": "can_play(Zeldas_Lullaby) and
+                ((glitch_megaflip and has_explosives and Deku_Shield) or
+                at('Spirit Temple Adult Central Chamber Known', is_adult))"
         },
         "exits": {
-            "Silver Gauntlets Hand Unknown": "child_can_hover and (adult_can_hover or Hookshot)",
-            "Spirit Temple Beyond Central Locked Door Unknown": "True"
+            "Spirit Temple Central Chamber Unknown": "True",
+            "Spirit Temple Beyond Central Locked Door Unknown": "(Small_Key_Spirit_Temple, 4)"
         }
     },
     {
@@ -253,6 +231,28 @@
         },
         "exits": {
             "Mirror Shield Hand Unknown": "child_can_hover and adult_can_hover"
+        }
+    },
+    {
+        "region_name": "Mirror Shield Hand Known",
+        "dungeon": "Spirit Temple",
+        "exits": {
+            "Mirror Shield Hand Unknown": "True",
+            "Desert Colossus": "True",
+            "Spirit Temple Lobby": "True",
+            "Silver Gauntlets Hand Known": "can_hover or can_use(Hookshot) or (can_use(Hover_Boots) and can_mega)",
+            "Spirit Temple Beyond Central Locked Door Known": "True"
+        }
+    },
+    {
+        "region_name": "Mirror Shield Hand Unknown",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Mirror Shield Chest": "True"
+        },
+        "exits": {
+            "Silver Gauntlets Hand Unknown": "child_can_hover and (adult_can_hover or Hookshot)",
+            "Spirit Temple Beyond Central Locked Door Unknown": "True"
         }
     },
     {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -4,7 +4,9 @@
         "dungeon": "Spirit Temple",
         "exits": {
             "Desert Colossus From Spirit Lobby": "True",
-            "Early Child Spirit Temple": "is_child or can_mega or Hover_Boots or (glitch_spirit_crawlspace and has_first_person_item)",
+            "Early Child Spirit Temple": "is_child or (glitch_weirdshot and can_mega) or
+                (glitch_slide and can_shield and can_use(Hover_Boots)) or
+                (glitch_spirit_crawlspace and has_first_person_item)",
             "Early Adult Spirit Temple": "can_use(Silver_Gauntlets) or
                 (glitch_strength2_blocks and (can_use(Hover_Boots) or (is_adult and can_bomb_slide))) or
                 (is_adult and has_first_person_item)",
@@ -18,27 +20,38 @@
         "region_name": "Early Child Spirit Temple",
         "dungeon": "Spirit Temple",
         "locations": {
-            "Spirit Temple Child Bridge Chest": "(can_use(Boomerang) or can_use(Slingshot) or can_use(Bow) or has_bombchus or can_mega or can_use(Hover_Boots)) and
-                (can_use(Sticks) or can_use(Megaton_Hammer) or is_adult or has_explosives or
-                    ( (Nuts or can_use(Boomerang)) and (can_use(Kokiri_Sword) or can_use(Slingshot)) ) )",
-            "Spirit Temple Child Early Torches Chest": "(is_adult and has_fire_source) or
-                (has_fire_source_with_torch and (here(is_adult) or
-                (
-                (can_use(Boomerang) or can_use(Slingshot) or has_bombchus or can_mega) and
-                (Sticks or has_explosives or
-                    ( (Nuts or can_use(Boomerang)) and
-                        (can_use(Kokiri_Sword) or can_use(Slingshot)) ) ))))",
-            "Spirit Temple GS Metal Fence": "is_adult or
-                (
-                (can_use(Boomerang) or can_use(Slingshot) or has_bombchus or can_mega) and
-                (Sticks or has_explosives or
-                    ( (Nuts or can_use(Boomerang)) and
-                        (can_use(Kokiri_Sword) or can_use(Slingshot)) ) ))",
-            "Nut Crate": "True"
+            # Duplicated in Child Spirit Temple Climb Known with alternate requirements
+            "Nut Crate": "
+                is_child or
+                (glitch_actor and Hookshot and
+                    ((can_shield and Hover_Boots and can_live_dmg(1.0)) or
+                    (has_explosives and can_live_dmg(1.5))))"
         },
         "exits": {
-            "Child Spirit Temple Climb": "(Small_Key_Spirit_Temple, 2) and
-                (is_child or (can_weirdshot and can_use(Longshot)) or can_use(Hover_Boots))"
+            # Can hookshot the fence and climb the upright bridge to clip through the ceiling
+            "Child Spirit Temple Across Bridges": "
+                here(
+                    is_adult or Sticks or has_explosives or can_use(Megaton_Hammer) or
+                    (Nuts and (can_use(Kokiri_Sword) or can_use(Slingshot)) )) and
+                here(
+                    can_use(Boomerang) or can_use(Slingshot) or can_use(Bow) or can_use(Hookshot) or has_bombchus or
+                    can_mega or can_use(Hover_Boots))",
+            "Child Spirit Temple Climb": "
+                (Small_Key_Spirit_Temple, 2) and
+                    (is_child or
+                    (can_weirdshot and Longshot) or
+                    (glitch_actor and Hookshot and
+                        ((can_shield and Hover_Boots and can_live_dmg(1.0)) or
+                        (has_explosives and can_live_dmg(1.5)))))"
+        }
+    },
+    {
+        "region_name": "Child Spirit Temple Across Bridges",
+        "dungeon": "Spirit Temple",
+        "locations": {
+            "Spirit Temple Child Bridge Chest": "True",
+            "Spirit Temple Child Early Torches Chest": "has_fire_source_with_torch",
+            "Spirit Temple GS Metal Fence": "True"
         }
     },
     {
@@ -51,7 +64,8 @@
                 or is_child or has_projectile(adult)",
             "Spirit Temple GS Sun on Floor Room": "can_use(Boomerang) or can_use(Hookshot) or
                 (can_child_damage and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love))) or 
-                (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love)))"
+                (is_adult and (can_live_dmg(0.5) or Fairy or can_use(Nayrus_Love)))",
+            "Nut Crate": "(Small_Key_Spirit_Temple, 5)"
         },
         "exits": {
             "Spirit Temple Central Chamber": "has_explosives"

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -215,7 +215,8 @@
                         (has_bombchus and
                             ((is_adult and has_2h_sword) or
                             can_use(Sticks) or can_use(Megaton_Hammer))))) or
-                    (can_mega and can_use(Iron_Boots))))"
+                    (can_mega and can_use(Iron_Boots))))",
+            "Desert Colossus": "(Small_Key_Spirit_Temple, 4) and has_explosives"
         }
     },
     {

--- a/data/Glitched World/Spirit Temple.json
+++ b/data/Glitched World/Spirit Temple.json
@@ -201,7 +201,17 @@
                 ((Small_Key_Spirit_Temple, 4) and (can_hover or (is_adult and can_shield))))",
             "Spirit Temple Top": "(Small_Key_Spirit_Temple, 5)",
             "Early Adult Spirit Temple": "(Small_Key_Spirit_Temple, 5)",
-            "Spirit Temple Boss Door": "can_use(Hookshot) and can_live_dmg(0.5) and Mirror_Shield and has_explosives and glitch_bk_skip_spirit"
+            # Use some precise jumps to climb the statue and clip into the head.
+            "Spirit Temple Boss Door": "
+                Boss_Key_Spirit_Temple or
+                (glitch_bk_skip_spirit and
+                    (can_use(Hover_Boots) or
+                    (can_hover and
+                        ((can_live_dmg(0.5) and shuffle_bosses == 'off') or
+                        (has_bombchus and
+                            ((is_adult and has_2h_sword) or
+                            can_use(Sticks) or can_use(Megaton_Hammer))))) or
+                    (can_mega and can_use(Iron_Boots))))"
         }
     },
     {
@@ -313,9 +323,6 @@
             "Spirit Temple Boss Key Chest": "can_play(Zeldas_Lullaby) and (can_live_dmg(1.0) or
                 (here(can_use(Bow) or can_qpa or (glitch_qpa and can_isg)) and can_use(Hookshot)))",
             "Spirit Temple Topmost Chest": "can_use(Mirror_Shield)"
-        },
-        "exits": {
-            "Spirit Temple Boss Door": "can_use(Mirror_Shield) and Boss_Key_Spirit_Temple"
         }
     }
 ]

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -77,8 +77,8 @@
             or (_is_adult_item(item) and is_adult and item)
             or (_is_magic_arrow(item) and is_adult and item and Bow and Magic_Meter)
             or (_is_child_item(item) and is_child and item)
-            or (_is_equipswap_item(item) and can_equipswap)
-            or (_is_equipswap_slingshot(item) and can_use(Bow) and can_equipswap)",
+            or (_is_equipswap_item(item) and can_equipswap and item)
+            or (_is_equipswap_slingshot(item) and can_use(Bow) and can_equipswap and item)",
     "_is_magic_item(item)": "item == Dins_Fire or item == Farores_Wind or item == Nayrus_Love or item == Lens_of_Truth",
     "_is_adult_item(item)": "item == Bow or item == Megaton_Hammer or item == Iron_Boots or item == Hover_Boots or item == Hookshot or item == Longshot or item == Silver_Gauntlets or item == Golden_Gauntlets or item == Goron_Tunic or item == Zora_Tunic or item == Scarecrow or item == Distant_Scarecrow or item == Mirror_Shield",
     "_is_child_item(item)": "item == Slingshot or item == Boomerang or item == Kokiri_Sword or item == Sticks or item == Deku_Shield",

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -145,7 +145,7 @@
     "can_ledge_cancel": "glitch_ledge_cancel and can_shield and Bombs",
     "can_ledge_cancel_chus": "glitch_ledge_cancel and can_shield and has_explosives",
     "can_damage_boost": "not_a_glitch_damage_boost and has_explosives and can_jumpslash and (can_live_dmg(0.5) or can_use(Nayrus_Love))",
-    "can_ib_dive": "glitch_ib_dive and can_isg and can_use(Iron_Boots) and has_cutscene_item",
+    "can_ib_dive": "can_isg and can_use(Iron_Boots) and has_cutscene_item",
     # Blue Fire works for this, but requiring 200 rupees every time for any glitch involving cutscene items is simply too cruel.
     # Beans, big poes, both letters, and weird egg are all also cutscene items, but they can all be used up so they can't be in logic.
     # I can't seem to add small poes or any kind of potion because it needs to be defined still. I've left it out for now but it could potentially be done.

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -145,6 +145,7 @@
     "can_ledge_cancel": "glitch_ledge_cancel and can_shield and Bombs",
     "can_ledge_cancel_chus": "glitch_ledge_cancel and can_shield and has_explosives",
     "can_damage_boost": "not_a_glitch_damage_boost and has_explosives and can_jumpslash and (can_live_dmg(0.5) or can_use(Nayrus_Love))",
+    "can_ib_dive": "glitch_ib_dive and can_isg and can_use(Iron_Boots) and has_cutscene_item",
     # Blue Fire works for this, but requiring 200 rupees every time for any glitch involving cutscene items is simply too cruel.
     # Beans, big poes, both letters, and weird egg are all also cutscene items, but they can all be used up so they can't be in logic.
     # I can't seem to add small poes or any kind of potion because it needs to be defined still. I've left it out for now but it could potentially be done.

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -152,6 +152,10 @@
     "has_cutscene_item": "(has_adult_trade_item and (is_adult or (glitch_equipswap and Dins_Fire))) or
         can_use(Dins_Fire) or can_use(Farores_Wind) or can_use(Nayrus_Love) or Ocarina or has_bottle_item",
     "has_bottle_item": "(Bugs or Fish or Fairy or Milk) and Bottle",
+    "bombchus_are_repeatable": "has_bombchus or (bombchus_in_logic and
+        ((not shuffle_interior_entrances and not shuffle_overworld_entrances and shopsanity == 'off') or
+        at('Market Bombchu Bowling', True)))",
+    "explosives_are_repeatable": "Bombs or bombchus_are_repeatable",
     
     # Bridge Requirements
     "has_all_stones": "Kokiri_Emerald and Goron_Ruby and Zora_Sapphire",

--- a/data/LogicHelpers.json
+++ b/data/LogicHelpers.json
@@ -63,8 +63,8 @@
     "can_use_projectile": "has_explosives or (is_adult and (Bow or Hookshot or (Boomerang and can_equipswap))) or (is_child and (Slingshot or Boomerang))",
     "has_projectile(for_age)": "has_explosives
             or (for_age == child and (Slingshot or Boomerang))
-            or (for_age == adult and (Bow or Hookshot or (Boomerang and can_equipswap)))
-            or (for_age == both and (Slingshot or Boomerang) and (Bow or Hookshot or (Boomerang and can_equipswap)))
+            or (for_age == adult and (Bow or Hookshot or (Boomerang and adult_can_equipswap)))
+            or (for_age == both and (Slingshot or Boomerang) and (Bow or Hookshot or (Boomerang and adult_can_equipswap)))
             or (for_age == either and (Slingshot or Boomerang or Bow or Hookshot))",
     "can_bonk_tree": "deadly_bonks == False or Fairy or can_use(Nayrus_Love)",
     "can_bonk_crate": "deadly_bonks == False or Fairy or can_use(Nayrus_Love) or can_blast_or_smash",
@@ -125,6 +125,9 @@
     "can_isg": "can_shield and (is_adult or Sticks or Kokiri_Sword or can_use(Megaton_Hammer))",
     "can_enemy_hover": "can_isg and glitch_hover",
     "can_hover": "has_explosives and can_enemy_hover",
+    "child_can_hover": "Deku_Shield and (Sticks or Kokiri_Sword or (Megaton_Hammer and child_can_equipswap)) and
+        has_explosives and glitch_hover",
+    "adult_can_hover": "(Hylian_Shield or Mirror_Shield) and has_explosives and glitch_hover",
     # Make sure to specify WHICH item you're expecting a weirdshot with.
     # Logically requires being adult as child crashes often while weirdshotting/weirdclipping
     "can_weirdshot": "is_adult and (has_explosives and can_shield and glitch_weirdshot)",
@@ -132,6 +135,8 @@
     "can_oi": "(Fish or Bugs) and glitch_oi",
     "can_groundjump": "can_shield and Bombs",
     "can_equipswap": "(Dins_Fire or (is_child and Sticks)) and glitch_equipswap",
+    "child_can_equipswap": "(Dins_Fire or Sticks) and glitch_equipswap",
+    "adult_can_equipswap": "Dins_Fire and glitch_equipswap",
     "can_bomb_slide": "has_explosives and can_shield and glitch_slide",
     "can_wess": "can_jumpslash and glitch_slide",
     # This can also be done with a ledge, but that's better to define on-location rather than with a helper.


### PR DESCRIPTION
This hardens age checks in Spirit Temple by splitting many of its regions into age-unknown and age-known variants. Also fixes the syntax error in Overworld.json and requires actually having the item when equip swapping.

I still want to fix potential keylocks from unrepeatable access to the hands, fix boss door access, and add more strats, particularly tricks in glitchless logic, strats using glitched damage, strats with dungeon shortcuts enabled, and supersliding to the Colossus hands from the arch. There are also parts where I don't know what the logic is expecting that I'd like to clarify or fix.